### PR TITLE
Add minimal template for GitHub repo page

### DIFF
--- a/portfolio/src/app/MinimalTemplate.tsx
+++ b/portfolio/src/app/MinimalTemplate.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface TemplateProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function MinimalTemplate({ title, children }: TemplateProps) {
+  return (
+    <main className="max-w-3xl mx-auto p-6 text-center">
+      <h1 className="text-2xl font-semibold mb-4">{title}</h1>
+      {children}
+    </main>
+  );
+}

--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -1,5 +1,6 @@
 // page.tsx
 import React from 'react';
+import MinimalTemplate from './MinimalTemplate';
 import { Repo } from './Repo';
 
 async function getRepos() {
@@ -15,27 +16,28 @@ export default async function Home() {
   const repos = await getRepos();
 
   return (
-    <div className="p-8 bg-gradient-to-r from-purple-600 to-indigo-600 min-h-screen text-white">
-      <h1 className="text-4xl font-bold mb-6">My GitHub Repos</h1>
+    <MinimalTemplate title="My GitHub Repos">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {repos.slice(0, 6).map((repo: Repo) => (
           <div
             key={repo.id}
-            className="backdrop-blur-md bg-white/10 border border-white/20 p-4 rounded-lg shadow hover:scale-105 transform transition"
+            className="border p-4 rounded hover:shadow transition"
           >
-            <h2 className="text-xl font-semibold">{repo.name}</h2>
-            <p className="text-sm text-gray-200">{repo.description}</p>
+            <h2 className="text-lg font-medium">{repo.name}</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              {repo.description}
+            </p>
             <a
               href={repo.html_url}
               target="_blank"
               rel="noreferrer"
-              className="text-blue-300 hover:underline"
+              className="text-blue-600 hover:underline"
             >
               View on GitHub
             </a>
           </div>
         ))}
       </div>
-    </div>
+    </MinimalTemplate>
   );
 }


### PR DESCRIPTION
## Summary
- add a `MinimalTemplate` component for simple layout styling
- update `page.tsx` to use the minimalist template and simpler styles

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684633e3490c83209fbf782e74eba3a0