### PR TITLE
Add subtle aurora glow around Earth

### DIFF
--- a/portfolio/src/app/components/AuroraGlow.tsx
+++ b/portfolio/src/app/components/AuroraGlow.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import { AdditiveBlending, BackSide, Color, ShaderMaterial, Vector3 } from 'three';
+
+interface AuroraGlowProps {
+  radius?: number;        // Scale of the aurora sphere relative to the earth
+  intensity?: number;     // Multiplier for glow brightness
+  fade?: number;          // Controls how quickly the glow fades
+  color?: string | number; // Color of the aurora
+}
+
+export default function AuroraGlow({
+  radius = 1.05,
+  intensity = 0.8,
+  fade = 1.5,
+  color = '#50fcd5',
+}: AuroraGlowProps) {
+  const materialRef = useRef<ShaderMaterial>(null);
+  const { camera } = useThree();
+
+  // Update view vector each frame so rim lighting responds to camera
+  useFrame(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.viewVector.value.copy(camera.position);
+    }
+  });
+
+  return (
+    <mesh scale={radius}>
+      <sphereGeometry args={[1, 64, 64]} />
+      <shaderMaterial
+        ref={materialRef}
+        transparent
+        side={BackSide}
+        blending={AdditiveBlending}
+        uniforms={{
+          glowColor: { value: new Color(color) },
+          viewVector: { value: new Vector3() },
+          intensity: { value: intensity },
+          fade: { value: fade },
+        }}
+        vertexShader={`
+          uniform vec3 viewVector;
+          uniform float intensity;
+          uniform float fade;
+          varying float vIntensity;
+          void main() {
+            vec3 vNormal = normalize(normalMatrix * normal);
+            vec3 viewDir = normalize(viewVector - (modelViewMatrix * vec4(position, 1.0)).xyz);
+            vIntensity = intensity * pow(1.0 - dot(vNormal, viewDir), fade);
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+          }
+        `}
+        fragmentShader={`
+          uniform vec3 glowColor;
+          varying float vIntensity;
+          void main() {
+            gl_FragColor = vec4(glowColor * vIntensity, vIntensity);
+          }
+        `}
+      />
+    </mesh>
+  );
+}

--- a/portfolio/src/app/components/SpinningEarth.tsx
+++ b/portfolio/src/app/components/SpinningEarth.tsx
@@ -5,6 +5,7 @@ import { Stars, useTexture } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { Suspense } from "react";
 import { OrbitControls } from "@react-three/drei";
+import AuroraGlow from "./AuroraGlow";
 
 type Offset = {
     x: number;
@@ -51,6 +52,7 @@ export default function SpinningEarth({ offset }: SpinningEarthProps) {
                         0
                     ]}>
                         <Earth />
+                        <AuroraGlow />
                     </group>
                     <Stars radius={300} depth={100} count={500} factor={6} />
                 </Suspense>


### PR DESCRIPTION
## Summary
- create `AuroraGlow` shader component for a rim aurora effect
- import and render the glow around the Earth model

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3be46b84832099ea6d1c99e12258