### PR TITLE
Split global styles into dedicated files

### DIFF
--- a/portfolio/src/app/layout.tsx
+++ b/portfolio/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import "./styles/theme.css";
+import "./styles/fonts.css";
+import "./styles/animations.css";
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 const geistSans = Geist({

--- a/portfolio/src/app/styles/animations.css
+++ b/portfolio/src/app/styles/animations.css
@@ -1,41 +1,3 @@
-@import "tailwindcss";
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500&family=Inter:wght@400;600&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;600&display=swap');
-
-
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --font-heading: 'Orbitron', sans-serif;
-  --font-body: 'Inter', sans-serif;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-
-}
-
-:root {
-  --font-heading: 'JetBrains Mono', monospace;
-  --font-body: 'Roboto Mono', monospace;
-}
-
 @keyframes shooting-star {
   0% {
     opacity: 0;
@@ -173,7 +135,6 @@ body {
     transform: perspective(1000px) rotateY(0deg);
   }
 }
-
 
 @layer utilities {
   @keyframes fadeSlideUp {

--- a/portfolio/src/app/styles/fonts.css
+++ b/portfolio/src/app/styles/fonts.css
@@ -1,0 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500&family=Inter:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;600&display=swap');
+
+:root {
+  --font-heading: 'Orbitron', sans-serif;
+  --font-body: 'Inter', sans-serif;
+}
+
+:root {
+  --font-heading: 'JetBrains Mono', monospace;
+  --font-body: 'Roboto Mono', monospace;
+}

--- a/portfolio/src/app/styles/theme.css
+++ b/portfolio/src/app/styles/theme.css
@@ -1,0 +1,25 @@
+@import "tailwindcss";
+
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0a0a0a;
+    --foreground: #ededed;
+  }
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+}


### PR DESCRIPTION
## Summary
- break up `globals.css` into smaller files
- reference new CSS files in layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68548c75d5dc8320b6fe4a5f88a86bc8