### PR TITLE
Fix Earth glow rendering artifacts

### DIFF
--- a/portfolio/src/app/components/background/Earth/EarthWithLayers.tsx
+++ b/portfolio/src/app/components/background/Earth/EarthWithLayers.tsx
@@ -5,6 +5,7 @@ import { useFrame } from "@react-three/fiber";
 import { useTexture } from "@react-three/drei";
 import * as THREE from "three";
 import GlowSphere from "./GlowSphere";
+import { Select } from "@react-three/postprocessing";
 
 export default function EarthWithLayers() {
     const earthRef = useRef<THREE.Mesh>(null);
@@ -25,7 +26,9 @@ export default function EarthWithLayers() {
     return (
         <group rotation={[0.41, 0, 0]}>
             {/* Glow effect around the Earth */}
-            <GlowSphere />
+            <Select enabled>
+                <GlowSphere />
+            </Select>
 
             {/* Cloud layer */}
             <mesh ref={cloudsRef}>

--- a/portfolio/src/app/components/background/Earth/GlowSphere.tsx
+++ b/portfolio/src/app/components/background/Earth/GlowSphere.tsx
@@ -28,12 +28,14 @@ export default function GlowSphere() {
             blending: THREE.AdditiveBlending,
             transparent: true,
             depthWrite: false,
+            depthTest: true,
             toneMapped: false,
+            side: THREE.BackSide,
         });
     }, []);
 
     return (
-        <mesh layers={1}>
+        <mesh layers={1} renderOrder={1}>
             {/* Slightly larger radius than clouds */}
             <sphereGeometry args={[1.06, 64, 64]} />
             <primitive object={glowMaterial} attach="material" />

--- a/portfolio/src/app/components/background/Earth/SpinningEarth.tsx
+++ b/portfolio/src/app/components/background/Earth/SpinningEarth.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import React, { Suspense } from "react";
+import React, { Suspense, useRef } from "react";
 import { Canvas } from "@react-three/fiber";
 import { Stars, OrbitControls } from "@react-three/drei";
+import * as THREE from "three";
 
-import { Bloom, EffectComposer } from "@react-three/postprocessing";
+import { EffectComposer, Selection, SelectiveBloom } from "@react-three/postprocessing";
 
 
 import EarthWithLayers from "./EarthWithLayers";
@@ -20,6 +21,7 @@ interface SpinningEarthProps {
 }
 
 export default function SpinningEarth({ offset }: SpinningEarthProps) {
+    const lightRef = useRef<THREE.DirectionalLight>(null);
     return (
         <div
             className="fixed inset-0 pointer-events-none z-0"
@@ -37,32 +39,37 @@ export default function SpinningEarth({ offset }: SpinningEarthProps) {
                     camera.layers.enable(1); // glow layer
 
                 }}>
-                <EffectComposer>
-                    <Bloom
-                        mipmapBlur
-                        luminanceThreshold={0.5}
-                        luminanceSmoothing={0.5}
-                        intensity={0}
-                    />
-                </EffectComposer>
+                <Selection>
+                    <EffectComposer>
+                        <SelectiveBloom
+                            selectionLayer={1}
+                            luminanceThreshold={0.5}
+                            luminanceSmoothing={0.5}
+                            intensity={0.6}
+                            mipmapBlur
+                            lights={[lightRef]}
+                        />
+                    </EffectComposer>
 
-                <ambientLight intensity={0.4} />
-                <directionalLight position={[5, 5, 5]} intensity={1} />
-                <Suspense fallback={null}>
-                    <group
-                        scale={0.4} // smaller than 1 makes it smaller
-                        position={[
-                            -(offset?.x * 0.05 || 0),
-                            0 - (offset?.y * 0.15 || 0), // more negative = lower
-                            0,
-                        ]}
-                    >
-                        <EarthWithLayers />
-                    </group>
+                    <ambientLight intensity={0.4} />
+                    <directionalLight ref={lightRef} position={[5, 5, 5]} intensity={1} />
 
-                    <Stars radius={100} depth={500} count={1000} factor={6} />
-                </Suspense>
-                <OrbitControls enableZoom={false} autoRotate autoRotateSpeed={0.05} />
+                    <Suspense fallback={null}>
+                        <group
+                            scale={0.4} // smaller than 1 makes it smaller
+                            position={[
+                                -(offset?.x * 0.05 || 0),
+                                0 - (offset?.y * 0.15 || 0), // more negative = lower
+                                0,
+                            ]}
+                        >
+                            <EarthWithLayers />
+                        </group>
+
+                        <Stars radius={100} depth={500} count={1000} factor={6} />
+                    </Suspense>
+                    <OrbitControls enableZoom={false} autoRotate autoRotateSpeed={0.05} />
+                </Selection>
             </Canvas>
         </div>
     );


### PR DESCRIPTION
## Summary
- render Earth glow on backside with depth settings
- mark glow mesh for bloom
- apply selective bloom and new layering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b348dc4d48320a078e8ec31d4170f