### PR TITLE
Update twinkle animation and Tailwind content paths

### DIFF
--- a/portfolio/src/app/components/background/Background.tsx
+++ b/portfolio/src/app/components/background/Background.tsx
@@ -146,7 +146,7 @@ export default function Background() {
                 .map((s) => (
                   <div
                     key={s.id}
-                    className="absolute rounded-full"
+                    className="absolute rounded-full animate-twinkle"
                     style={{
                       left: s.left,
                       top: s.top,
@@ -154,10 +154,7 @@ export default function Background() {
                       width: `${0.5 + Math.random() * (2 / layer)}px`,
                       height: `${0.5 + Math.random() * (2 / layer)}px`,
                       opacity: 0.5 + Math.random() * (0.1 / layer), // higher min opacity, less range
-                      animationName: 'twinkle',
                       animationDuration: `${1 + Math.random() * 2}s`, // slower twinkle
-                      animationTimingFunction: 'ease-in',
-                      animationIterationCount: 'infinite',
                       animationDelay: s.delay,
                     }}
                   />

--- a/portfolio/tailwind.config.js
+++ b/portfolio/tailwind.config.js
@@ -1,8 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- include `src` directory in Tailwind `content` glob
- use Tailwind's `animate-twinkle` class for stars

## Testing
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685b440b332c8320a068a582d06f66cc