### PR TITLE
Remove unused fonts

### DIFF
--- a/portfolio/src/app/layout.tsx
+++ b/portfolio/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./styles/theme.css";
 import "./styles/fonts.css";
 import "./styles/animations.css";
@@ -8,19 +7,6 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import Header from "./components/Header";
 import { Footer } from "./components/Footer";
 import ParallaxHandler from "./components/ParallaxHandler";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-  display: "swap",
-  preload: false,
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-  preload: false,
-});
 
 export const metadata: Metadata = {
   title: "Portfolio | Cameron Loveland",
@@ -37,7 +23,7 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="https://github.com/cameronloveland.png" />
       </head>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <ParallaxHandler>
           <Header />
           <main className="flex-1">{children}</main>

--- a/portfolio/src/app/styles/fonts.css
+++ b/portfolio/src/app/styles/fonts.css
@@ -1,11 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500&family=Inter:wght@400;600&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;600&display=swap');
-
-:root {
-  --font-heading: 'Orbitron', sans-serif;
-  --font-body: 'Inter', sans-serif;
-}
 
 :root {
   --font-heading: 'JetBrains Mono', monospace;

--- a/portfolio/src/app/styles/theme.css
+++ b/portfolio/src/app/styles/theme.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-body);
+  --font-mono: var(--font-heading);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- drop Orbitron, Inter, and Geist fonts
- keep JetBrains Mono, Roboto Mono, and Font Awesome

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685dec4a3d2083209c68687f464d142e