### PR TITLE
Add nebula animation utilities

### DIFF
--- a/portfolio/src/app/styles/animations.css
+++ b/portfolio/src/app/styles/animations.css
@@ -239,3 +239,47 @@
   image-rendering: auto;
   backface-visibility: hidden;
 }
+
+@layer utilities {
+  @keyframes nebulaFloat {
+    0% {
+      transform: translate(-5%, 0) scale(1) rotate(0deg);
+    }
+    25% {
+      transform: translate(5%, -10%) scale(1.05) rotate(2deg);
+    }
+    50% {
+      transform: translate(-10%, 5%) scale(1.1) rotate(-2deg);
+    }
+    75% {
+      transform: translate(5%, 10%) scale(1.05) rotate(2deg);
+    }
+    100% {
+      transform: translate(-5%, 0) scale(1) rotate(0deg);
+    }
+  }
+
+  @keyframes nebulaPulse {
+    0%,
+    100% {
+      opacity: 0.4;
+    }
+    50% {
+      opacity: 0.8;
+    }
+  }
+
+  .animate-nebula-float {
+    animation: nebulaFloat 45s ease-in-out infinite;
+    will-change: transform;
+  }
+
+  .animate-nebula-pulse {
+    animation: nebulaPulse 30s ease-in-out infinite;
+    will-change: opacity;
+  }
+
+  .nebula-bg {
+    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0) 70%);
+  }
+}


### PR DESCRIPTION
## Summary
- add nebulaFloat and nebulaPulse animations in raw CSS
- provide animate-nebula-float and animate-nebula-pulse utility classes
- include optional nebula-bg gradient utility

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed)*
- `npm run format` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f43deb0588320b93ff12f2d3b37d0