### PR TITLE
Add holographic AR panels

### DIFF
--- a/portfolio/src/app/layout.tsx
+++ b/portfolio/src/app/layout.tsx
@@ -7,6 +7,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import Header from "../components/Header";
 import { Footer } from "../components/Footer";
 import ParallaxHandler from "../components/ParallaxHandler";
+import ARPanels from "../components/ARPanels";
 
 export const metadata: Metadata = {
   title: "Portfolio | Cameron Loveland",
@@ -28,6 +29,7 @@ export default function RootLayout({
           <Header />
           <main className="flex-1">{children}</main>
           <Footer />
+          <ARPanels />
         </ParallaxHandler>
       </body>
     </html>

--- a/portfolio/src/components/ARPanels.tsx
+++ b/portfolio/src/components/ARPanels.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Image from 'next/image';
+import useMouseParallax from '@/hooks/useMouseParallax';
+
+function LeftARPanel() {
+  const offset = useMouseParallax(5);
+
+  return (
+    <div
+      className="pointer-events-none fixed left-4 top-8 bottom-8 w-[300px] h-[80vh] z-20 bg-cyan-300/10 backdrop-blur-sm border border-cyan-500/20 rounded-md ring-1 ring-cyan-500/30 shadow-[0_0_20px_rgba(56,189,248,0.25)] text-cyan-300 font-mono flex flex-col"
+      style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
+    >
+      <h2 className="p-3 text-center text-sm uppercase font-bold border-b border-cyan-500/20">
+        Hackathon Projects
+      </h2>
+      <div className="flex-1 overflow-y-auto p-3 space-y-1 text-xs">
+        <p>Project Alpha</p>
+        <p>Project Beta</p>
+        <p>Project Gamma</p>
+      </div>
+    </div>
+  );
+}
+
+function RightARPanel() {
+  const offset = useMouseParallax(5);
+
+  return (
+    <div
+      className="pointer-events-none fixed right-4 top-8 bottom-8 w-[300px] h-[80vh] z-20 bg-cyan-300/10 backdrop-blur-sm border border-cyan-500/20 rounded-md ring-1 ring-cyan-500/30 shadow-[0_0_20px_rgba(56,189,248,0.25)] text-cyan-300 font-mono flex flex-col"
+      style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
+    >
+      <h2 className="p-3 text-center text-sm uppercase font-bold border-b border-cyan-500/20">
+        Captain’s Log Dev Blog
+      </h2>
+      <div className="flex-1 overflow-y-auto p-3 space-y-2 text-xs">
+        <div className="flex gap-2 items-start">
+          <Image src="/next.svg" alt="Blog" width={40} height={40} className="rounded-sm" />
+          <p className="flex-1">First Entry: Launch Sequence Completed</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ARPanels() {
+  return (
+    <>
+      <LeftARPanel />
+      <RightARPanel />
+    </>
+  );
+}

--- a/portfolio/src/hooks/useMouseParallax.ts
+++ b/portfolio/src/hooks/useMouseParallax.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function useMouseParallax(intensity: number = 5) {
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const handle = (e: CustomEvent<{ x: number; y: number }>) => {
+      setOffset({ x: e.detail.x * intensity, y: e.detail.y * intensity });
+    };
+
+    document.addEventListener('earthParallax', handle as EventListener);
+    return () => document.removeEventListener('earthParallax', handle as EventListener);
+  }, [intensity]);
+
+  return offset;
+}


### PR DESCRIPTION
## Summary
- add `useMouseParallax` hook to listen to `earthParallax`
- create translucent `ARPanels` component for left and right HUD panels
- include AR panels in app `layout`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867727d07b88320aca45faca3111cc4