### PR TITLE
Add auto scrolling and style updates to Captain's Log

### DIFF
--- a/portfolio/src/styles/theme.css
+++ b/portfolio/src/styles/theme.css
@@ -34,6 +34,18 @@ body {
   scrollbar-width: none;
 }
 
+.scrollbar-dark {
+  scrollbar-color: #555 #222;
+}
+.scrollbar-dark::-webkit-scrollbar {
+  width: 8px;
+  background-color: #222;
+}
+.scrollbar-dark::-webkit-scrollbar-thumb {
+  background-color: #555;
+  border-radius: 4px;
+}
+
 .hud-aside-container {
   @apply w-full max-w-2xl bg-neutral-900/60 backdrop-blur-none text-white rounded-sm border border-neutral-800 shadow-lg overflow-hidden mb-12;
   max-height: 25vh;


### PR DESCRIPTION
## Summary
- add automatic scroll behavior with hover/pause support in `CaptainsLogSidebar`
- show numbered log entries and dark custom scrollbars

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68680a302a6883208b31a381ee07b8f7