### PR TITLE
Refine bottom HUD styling

### DIFF
--- a/portfolio/src/components/hud/CaptainsLogSidebar.tsx
+++ b/portfolio/src/components/hud/CaptainsLogSidebar.tsx
@@ -87,8 +87,9 @@ export default function CaptainsLogSidebar() {
     };
 
     return (
+        <div className="hud-panel">
         <aside className="hud-aside-container">
-            <div className="flex justify-between items-center px-4 py-2 border-b border-neutral-800 bg-neutral-950 text-sm font-semibold uppercase text-neutral-400 overflow-hidden">
+            <div className="flex justify-between items-center px-4 py-2 bg-[#0c0f1c]/80 border-b border-cyan-400/10 text-cyan-300 text-sm font-semibold uppercase overflow-hidden">
                 <span>
                     Recent – {logType === "pulls" ? "Pull Requests" : logType.charAt(0).toUpperCase() + logType.slice(1)}
                 </span>
@@ -99,11 +100,7 @@ export default function CaptainsLogSidebar() {
             </div>
             <div className="h-[1px] w-full">
                 <motion.div
-                    className={`h-full ${{
-                        commits: 'bg-sky-500',
-                        pulls: 'bg-purple-500',
-                    }[logType] ?? 'bg-blue-500'
-                        }`}
+                    className="h-full bg-cyan-400"
                     animate={{ width: `${progress}%` }}
                     transition={{ ease: 'linear', duration: 0.1 }} // Smooth and continuous
                 />
@@ -114,10 +111,7 @@ export default function CaptainsLogSidebar() {
             >
                 <AnimatePresence initial={false}>
                     {entries.map((entry, i) => {
-                        const levelClass = {
-                            commits: 'bg-sky-900 text-sky-300',
-                            pulls: 'bg-purple-900 text-purple-300',
-                        }[logType] || 'bg-neutral-800 text-neutral-400';
+                        const levelClass = 'bg-cyan-800 text-cyan-300';
 
                         return (
                             <motion.li
@@ -146,15 +140,10 @@ export default function CaptainsLogSidebar() {
                                             href={entry.url}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            className={`text-xs font-semibold px-3 py-1 rounded-md shadow-md
-                                                ${{
-                                                    commits: 'bg-sky-600 text-white hover:bg-sky-500',
-                                                    pulls: 'bg-purple-600 text-white hover:bg-purple-500',
-                                                }[logType] || 'bg-neutral-600 text-white hover:bg-neutral-500'}
-                                            `}
-                                        >
-                                            View →
-                                        </a>
+                                            className="text-xs font-semibold px-3 py-1 rounded-md shadow-md bg-cyan-600 text-white hover:bg-cyan-400"
+                                            >
+                                                View →
+                                            </a>
                                     </div>
                                 )}
 
@@ -164,5 +153,6 @@ export default function CaptainsLogSidebar() {
                 </AnimatePresence>
             </ul>
         </aside>
+        </div>
     );
 }

--- a/portfolio/src/components/hud/Projects.tsx
+++ b/portfolio/src/components/hud/Projects.tsx
@@ -17,8 +17,9 @@ export default function Projects({ repos }: ProjectsProps) {
     const displayRepos = repos ?? [];
 
     return (
-        <aside className="hud-aside-container">
-            <div className="flex justify-between items-center px-4 py-2 border-b border-neutral-800 bg-neutral-950 text-sm font-semibold uppercase text-neutral-400">
+        <div className="hud-panel">
+            <aside className="hud-aside-container">
+            <div className="flex justify-between items-center px-4 py-2 bg-[#0c0f1c]/80 border-b border-cyan-400/10 text-cyan-300 text-sm font-semibold uppercase">
                 <span>Featured Projects</span>
                 <span className="text-xs font-normal text-neutral-500">
                     {displayRepos.length} total
@@ -65,6 +66,7 @@ export default function Projects({ repos }: ProjectsProps) {
                     </li>
                 ))}
             </ul>
-        </aside>
+            </aside>
+        </div>
     );
 }

--- a/portfolio/src/components/hud/Terminal.tsx
+++ b/portfolio/src/components/hud/Terminal.tsx
@@ -139,9 +139,10 @@ const Terminal: React.FC = () => {
     };
 
     return (
-        <div className="hud-aside-container bg-black text-blue-400 font-mono text-sm flex flex-col h-full">
+        <div className="hud-panel">
+        <div className="hud-aside-container font-mono text-sm flex flex-col h-full text-cyan-300">
             {/* Header */}
-            <div className="sticky top-0 z-10 flex justify-between items-center px-4 py-2 border-b border-neutral-800 bg-neutral-950 text-sm font-semibold uppercase text-neutral-400">
+            <div className="sticky top-0 z-10 flex justify-between items-center px-4 py-2 bg-[#0c0f1c]/80 border-b border-cyan-400/10 text-cyan-300 text-sm font-semibold uppercase">
                 <span>Terminal</span>
             </div>
             {/* Body */}
@@ -172,7 +173,7 @@ const Terminal: React.FC = () => {
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
                         onKeyDown={handleInput}
-                        className="bg-transparent outline-none flex-1 text-blue-400 placeholder-blue-500"
+                        className="bg-transparent outline-none flex-1 text-cyan-300 placeholder-cyan-500"
                         placeholder="Type a command..."
                         autoFocus
                     />
@@ -201,6 +202,7 @@ const Terminal: React.FC = () => {
                     </div>
                 )}
             </div>
+        </div>
         </div>
     );
 };

--- a/portfolio/src/styles/theme.css
+++ b/portfolio/src/styles/theme.css
@@ -35,7 +35,11 @@ body {
 }
 
 .hud-aside-container {
-  @apply w-full max-w-2xl bg-neutral-900/60 backdrop-blur-none text-white rounded-sm border border-neutral-800 shadow-lg overflow-hidden mb-12;
+  @apply w-full max-w-2xl overflow-hidden mb-12;
   max-height: 25vh;
   min-height: 25vh;
+}
+
+.hud-panel {
+  @apply bg-[#0c0f1c]/60 border border-cyan-400/20 shadow-[0_0_10px_1px_rgba(34,255,255,0.15)] backdrop-blur-md rounded-2xl p-4;
 }


### PR DESCRIPTION
## Summary
- add new `hud-panel` utility for consistent glowing panel style
- wrap HUD components in the new panel
- unify headers, progress bar, and button colors
- simplify Captain's Log levels

## Testing
- `npm run format` *(fails: Missing script)*
- `npm run lint`
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68687e3b055483208ba9021e52ead8b4