### PR TITLE
Add sliding radio comms HUD

### DIFF
--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -4,7 +4,6 @@ import { EarthBackground } from '../components/background';
 import { CaptainsLogSidebar, Projects } from '../components/hud';
 import Terminal from '../components/hud/Terminal';
 import { getReposWithReadme } from '../lib/github';
-import RadioPlayer from '@/components/RadioPlayer';
 
 
 export default async function Home() {

--- a/portfolio/src/components/RadioPlayer.tsx
+++ b/portfolio/src/components/RadioPlayer.tsx
@@ -16,6 +16,7 @@ export default function RadioPlayer() {
     const audioRef = useRef<HTMLAudioElement>(null);
     const [stationIndex, setStationIndex] = useState(5);
     const [isPlaying, setIsPlaying] = useState(true);
+    const [open, setOpen] = useState(false);
 
     const currentStation = stations[stationIndex];
 
@@ -76,43 +77,47 @@ export default function RadioPlayer() {
     };
 
     return (
-        <div className="relative w-full max-w-3xl mx-auto bg-black/50 border border-cyan-500/30 rounded-2xl backdrop-blur-md shadow-lg flex flex-col items-center px-6 py-4 space-y-4 hud-panel mt-4">
-            {/* Station Display */}
-            <div
-                className="w-full text-center text-2xl text-cyan-200 tracking-widest digital-glow bg-black/40 border border-cyan-500/20 rounded-md py-2 px-4 shadow-inner"
-                style={{ fontFamily: 'var(--font-digital)' }}
-            >
-                {isPlaying ? currentStation.name : 'RADIO STANDBY'}
-            </div>
-
-            {/* Tuner Buttons */}
-            <div className="flex gap-2 flex-wrap justify-center">
-                {stations.map((station, idx) => {
-                    const isActive = idx === stationIndex;
-                    return (
-                        <button
-                            key={station.name}
-                            onClick={() => changeStation(idx)}
-                            className={`px-3 py-1 text-xs rounded-full border transition ${isActive
-                                ? 'bg-cyan-400 text-black border-cyan-400'
-                                : 'bg-transparent text-cyan-300 border-cyan-500/30 hover:bg-cyan-700/20'
-                                }`}
-                        >
-                            {String(idx + 1).padStart(2, '0')}
-                        </button>
-                    );
-                })}
-            </div>
-
-            {/* Play / Pause Button */}
+        <div className="fixed top-0 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center pointer-events-none">
             <button
-                onClick={togglePlay}
-                className="w-[60px] h-[60px] rounded-full bg-cyan-500 text-black font-bold flex items-center justify-center text-xl shadow-md hover:bg-cyan-400 transition"
+                onClick={() => setOpen(!open)}
+                className={`pointer-events-auto text-xs px-3 py-1 rounded-b-md border border-cyan-500/40 bg-neutral-900/80 text-cyan-300 hover:bg-neutral-800 transition ${isPlaying ? 'animate-pulse-slow' : ''}`}
             >
-                {isPlaying ? '❚❚' : '▶'}
+                ▲ COMMS
             </button>
-
-            <audio ref={audioRef} src={currentStation.url} preload="none" />
+            <div className={`transition-transform duration-300 transform ${open ? 'translate-y-0' : '-translate-y-full'} pointer-events-auto w-full flex justify-center`}> 
+                <div className={`hud-panel mt-1 w-full max-w-3xl ${open ? 'ring-1 ring-cyan-400/40' : ''} flex flex-col items-center space-y-4 px-6 py-4`}>
+                    <div
+                        className="w-full text-center text-2xl text-cyan-200 tracking-widest digital-glow bg-black/40 border border-cyan-500/20 rounded-md py-2 px-4 shadow-inner"
+                        style={{ fontFamily: 'var(--font-digital)' }}
+                    >
+                        {isPlaying ? currentStation.name : 'RADIO STANDBY'}
+                    </div>
+                    <div className="flex gap-2 flex-wrap justify-center">
+                        {stations.map((station, idx) => {
+                            const isActive = idx === stationIndex;
+                            return (
+                                <button
+                                    key={station.name}
+                                    onClick={() => changeStation(idx)}
+                                    className={`px-3 py-1 text-xs rounded-full border transition ${isActive
+                                        ? 'bg-cyan-400 text-black border-cyan-400'
+                                        : 'bg-transparent text-cyan-300 border-cyan-500/30 hover:bg-cyan-700/20'
+                                        }`}
+                                >
+                                    {String(idx + 1).padStart(2, '0')}
+                                </button>
+                            );
+                        })}
+                    </div>
+                    <button
+                        onClick={togglePlay}
+                        className="w-[60px] h-[60px] rounded-full bg-cyan-500 text-black font-bold flex items-center justify-center text-xl shadow-md hover:bg-cyan-400 transition"
+                    >
+                        {isPlaying ? '❚❚' : '▶'}
+                    </button>
+                    <audio ref={audioRef} src={currentStation.url} preload="none" />
+                </div>
+            </div>
         </div>
     );
 }

--- a/portfolio/tailwind.config.js
+++ b/portfolio/tailwind.config.js
@@ -32,6 +32,7 @@ module.exports = {
         twinkle: 'twinkle 2s ease-in-out infinite',
         nebulaFloat: 'nebulaFloat 60s ease-in-out infinite',
         nebulaPulse: 'nebulaPulse 8s ease-in-out infinite',
+        'pulse-slow': 'pulse 3s ease-in-out infinite',
       },
       fontFamily: {
         heading: ['var(--font-heading)', 'sans-serif'],


### PR DESCRIPTION
## Summary
- create sliding HUD for radio player
- hide unused RadioPlayer import
- add pulse-slow animation option

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_686c7df8c18c8320bf55b072856235e4