### PR TITLE
Add blinking terminal cursor

### DIFF
--- a/portfolio/src/components/hud/Terminal.tsx
+++ b/portfolio/src/components/hud/Terminal.tsx
@@ -173,10 +173,11 @@ const Terminal: React.FC = () => {
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
                         onKeyDown={handleInput}
-                        className="bg-transparent outline-none flex-1 text-cyan-300 placeholder-cyan-500"
+                        className="bg-transparent outline-none flex-1 text-cyan-300 placeholder-cyan-500 caret-transparent"
                         placeholder="Type a command..."
                         autoFocus
                     />
+                    <span className="animate-cursorBlink font-bold text-cyan-300 ml-1">█</span>
                 </div>
                 <div ref={logEndRef} />
                 {showYesNo && (

--- a/portfolio/tailwind.config.js
+++ b/portfolio/tailwind.config.js
@@ -5,19 +5,23 @@ module.exports = {
   ],
   theme: {
     extend: {
-      keyframes: {
-        twinkle: {
-          '0%, 100%': {
-            opacity: '0.5',
-            transform: 'scale(1)',
+        keyframes: {
+          twinkle: {
+            '0%, 100%': {
+              opacity: '0.5',
+              transform: 'scale(1)',
+            },
+            '50%': {
+              opacity: '0.8',
+              transform: 'scale(1.1)',
+            },
           },
-          '50%': {
-            opacity: '0.8',
-            transform: 'scale(1.1)',
+          cursorBlink: {
+            '0%, 100%': { opacity: '1' },
+            '50%': { opacity: '0' },
           },
-        },
-        nebulaFloat: {
-          '0%': { transform: 'translate(0,0) scale(1)' },
+          nebulaFloat: {
+            '0%': { transform: 'translate(0,0) scale(1)' },
           '25%': { transform: 'translate(120px,-80px) scale(1.05)' },
           '50%': { transform: 'translate(-130px,60px) scale(1.1)' },
           '75%': { transform: 'translate(80px,120px) scale(1.05)' },
@@ -32,6 +36,7 @@ module.exports = {
         twinkle: 'twinkle 2s ease-in-out infinite',
         nebulaFloat: 'nebulaFloat 60s ease-in-out infinite',
         nebulaPulse: 'nebulaPulse 8s ease-in-out infinite',
+        cursorBlink: 'cursorBlink 1s step-end infinite',
       },
       fontFamily: {
         heading: ['var(--font-heading)', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add cursorBlink keyframes/animation in Tailwind config
- hide default input caret and append blinking block cursor

## Testing
- `npm run lint` *(fails: 'RadioPlayer' is defined but never used)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686dc3c62cfc8320ba4ba010a6d89d36