### PR TITLE
Add HUD scroll utility and auto-scroll for projects

### DIFF
--- a/portfolio/src/components/hud/CaptainsLogSidebar.tsx
+++ b/portfolio/src/components/hud/CaptainsLogSidebar.tsx
@@ -164,7 +164,7 @@ export default function CaptainsLogSidebar() {
                     />
                 </div>
                 <div className="relative h-[calc(25vh-3rem)]">
-                    <div className="overflow-y-auto scrollbar-thin scrollbar-thumb-cyan-400/30 h-full">
+                    <div className="hud-scroll h-full">
                         <ul ref={scrollRef} className="space-y-2 pr-2">
 
                             <AnimatePresence initial={false}>

--- a/portfolio/src/styles/theme.css
+++ b/portfolio/src/styles/theme.css
@@ -55,18 +55,23 @@ body {
   @apply hover:animate-pulse hover:text-cyan-300 transition;
 }
 
-/* HUD Scrollbar Styling – sci-fi cyan glow */
-::-webkit-scrollbar {
+/* Shared scrolling utility for HUD panels */
+.hud-scroll {
+  overflow-y: auto;
+  max-height: calc(25vh - 3rem);
+  scrollbar-width: thin; /* Firefox */
+}
+
+.hud-scroll::-webkit-scrollbar {
   width: 10px;
 }
 
-::-webkit-scrollbar-track {
-  background: rgba(12, 15, 28, 0.3);
-  /* dim HUD panel base */
+.hud-scroll::-webkit-scrollbar-track {
+  background: rgba(12, 15, 28, 0.3); /* dim HUD panel base */
   border-radius: 8px;
 }
 
-::-webkit-scrollbar-thumb {
+.hud-scroll::-webkit-scrollbar-thumb {
   background: linear-gradient(180deg, rgba(103, 232, 249, 0.4), rgba(0, 188, 212, 0.6));
   border-radius: 8px;
   border: 1px solid rgba(0, 255, 255, 0.3);
@@ -77,7 +82,7 @@ body {
   transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
-::-webkit-scrollbar-thumb:hover {
+.hud-scroll::-webkit-scrollbar-thumb:hover {
   background: linear-gradient(180deg, rgba(103, 232, 249, 0.6), rgba(0, 188, 212, 0.8));
   box-shadow:
     0 0 8px rgba(0, 255, 255, 0.6),


### PR DESCRIPTION
## Summary
- add a reusable `.hud-scroll` class with sci‑fi scrollbar styling
- apply new class in `CaptainsLogSidebar`
- convert `Projects` component to a client component
- implement auto-scroll behavior on projects list
- wrap list in new HUD scroll container

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f1c2c2d688320b1df091368dde934