### PR TITLE
Add astronaut targeting hover effect

### DIFF
--- a/portfolio/src/styles/theme.css
+++ b/portfolio/src/styles/theme.css
@@ -84,3 +84,52 @@ body {
     0 0 16px rgba(0, 255, 255, 0.4),
     inset 0 0 6px rgba(0, 255, 255, 0.5);
 }
+
+.target-lock {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 260px;
+  height: 260px;
+  margin-left: -130px;
+  margin-top: -130px;
+  border: 2px dashed rgba(34, 255, 255, 0.8);
+  border-radius: 50%;
+  pointer-events: none;
+  box-shadow: 0 0 12px rgba(34, 255, 255, 0.5), 0 0 24px rgba(34, 255, 255, 0.3);
+  animation: target-lock 1.6s linear infinite;
+}
+
+.target-lock::before,
+.target-lock::after {
+  content: "";
+  position: absolute;
+  background: rgba(34, 255, 255, 0.8);
+}
+
+.target-lock::before {
+  width: 2px;
+  height: 100%;
+  left: 50%;
+  top: 0;
+  transform: translateX(-50%);
+}
+
+.target-lock::after {
+  height: 2px;
+  width: 100%;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+@keyframes target-lock {
+  0% {
+    transform: translate(-50%, -50%) scale(1) rotate(0deg);
+    opacity: 0.7;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1.1) rotate(360deg);
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
## Summary
- add target lock hover logic in `FloatingAstronaut`
- create reusable `.target-lock` CSS animation in `theme.css`

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686f1daad2348320a66d93da3e238d12