### PR TITLE
Add docked radio footer

### DIFF
--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -3,6 +3,7 @@ import FloatingAstronaut from '../components/FloatingAstronaut';
 import { EarthBackground } from '../components/background';
 import { CaptainsLogSidebar, Projects } from '../components/hud';
 import Terminal from '../components/hud/Terminal';
+import RadioPlayer from '../components/RadioPlayer';
 import { getReposWithReadme } from '../lib/github';
 
 
@@ -80,6 +81,7 @@ export default async function Home() {
 
           </section>
         </main>
+        <RadioPlayer />
       </div>
     </>
   );

--- a/portfolio/src/components/RadioPlayer.tsx
+++ b/portfolio/src/components/RadioPlayer.tsx
@@ -75,44 +75,48 @@ export default function RadioPlayer() {
         });
     };
 
+
     return (
-        <div className="relative w-full max-w-3xl mx-auto bg-black/50 border border-cyan-500/30 rounded-2xl backdrop-blur-md shadow-lg flex flex-col items-center px-6 py-4 space-y-4 hud-panel mt-4">
-            {/* Station Display */}
-            <div
-                className="w-full text-center text-2xl text-cyan-200 tracking-widest digital-glow bg-black/40 border border-cyan-500/20 rounded-md py-2 px-4 shadow-inner"
-                style={{ fontFamily: 'var(--font-digital)' }}
-            >
-                {isPlaying ? currentStation.name : 'RADIO STANDBY'}
+        <div className="radio-footer">
+            <div className="flex-1 hidden sm:block" />
+
+            <div className="flex flex-col items-center justify-center text-center flex-1">
+                <div
+                    className="station-title text-cyan-200 digital-glow"
+                    style={{ fontFamily: 'var(--font-digital)' }}
+                >
+                    {isPlaying ? currentStation.name : 'RADIO STANDBY'}
+                </div>
+                <div className="equalizer mt-1">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                        <span key={i} className="bar" />
+                    ))}
+                </div>
             </div>
 
-            {/* Tuner Buttons */}
-            <div className="flex gap-2 flex-wrap justify-center">
+            <div className="controls flex items-center justify-end gap-2 flex-1 flex-wrap">
                 {stations.map((station, idx) => {
                     const isActive = idx === stationIndex;
                     return (
                         <button
                             key={station.name}
                             onClick={() => changeStation(idx)}
-                            className={`px-3 py-1 text-xs rounded-full border transition ${isActive
-                                ? 'bg-cyan-400 text-black border-cyan-400'
-                                : 'bg-transparent text-cyan-300 border-cyan-500/30 hover:bg-cyan-700/20'
-                                }`}
+                            className={`px-3 py-1 text-xs rounded-full border transition ${
+                                isActive
+                                    ? 'bg-cyan-400 text-black border-cyan-400'
+                                    : 'bg-transparent text-cyan-300 border-cyan-500/30 hover:bg-cyan-700/20'
+                            }`}
                         >
                             {String(idx + 1).padStart(2, '0')}
                         </button>
                     );
                 })}
+
+                <button onClick={togglePlay} title="Play/Pause" className="w-10 h-10 rounded-full bg-cyan-500 text-black font-bold flex items-center justify-center text-lg shadow-md hover:bg-cyan-400 transition">
+                    {isPlaying ? '❚❚' : '▶'}
+                </button>
+                <audio ref={audioRef} src={currentStation.url} preload="none" />
             </div>
-
-            {/* Play / Pause Button */}
-            <button
-                onClick={togglePlay}
-                className="w-[60px] h-[60px] rounded-full bg-cyan-500 text-black font-bold flex items-center justify-center text-xl shadow-md hover:bg-cyan-400 transition"
-            >
-                {isPlaying ? '❚❚' : '▶'}
-            </button>
-
-            <audio ref={audioRef} src={currentStation.url} preload="none" />
         </div>
     );
 }

--- a/portfolio/src/styles/theme.css
+++ b/portfolio/src/styles/theme.css
@@ -84,3 +84,50 @@ body {
     0 0 16px rgba(0, 255, 255, 0.4),
     inset 0 0 6px rgba(0, 255, 255, 0.5);
 }
+
+.radio-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background-color: rgba(12, 15, 28, 0.6);
+  border-top: 1px solid rgba(34, 255, 255, 0.2);
+  box-shadow: 0 0 10px 1px rgba(34, 255, 255, 0.15);
+  backdrop-filter: blur(12px);
+}
+
+@media (min-width: 640px) {
+  .radio-footer {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.radio-footer .equalizer {
+  display: flex;
+  align-items: flex-end;
+  height: 12px;
+  gap: 2px;
+}
+
+.radio-footer .bar {
+  width: 3px;
+  background-color: rgba(103, 232, 249, 0.8);
+  animation: equalize 1s ease-in-out infinite;
+  transform-origin: bottom;
+}
+
+.radio-footer .bar:nth-child(2) { animation-delay: -0.2s; }
+.radio-footer .bar:nth-child(3) { animation-delay: -0.4s; }
+.radio-footer .bar:nth-child(4) { animation-delay: -0.6s; }
+.radio-footer .bar:nth-child(5) { animation-delay: -0.8s; }
+
+@keyframes equalize {
+  0%, 100% { height: 20%; }
+  50% { height: 100%; }
+}


### PR DESCRIPTION
## Summary
- add RadioPlayer to page and tweak layout
- create footer HUD styles with equalizer animation
- update player component for docked footer without changing controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f1d34ad5c83209e01dceb0fef50f0