### PR TITLE
Add HUD ControlPanel with global scene controls

### DIFF
--- a/portfolio/package-lock.json
+++ b/portfolio/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
-        "three": "^0.177.0"
+        "three": "^0.177.0",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -8061,9 +8062,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
-      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -19,7 +19,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "three": "^0.177.0"
+    "three": "^0.177.0",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -1,7 +1,7 @@
 import CockpitOverlay from '@/components/background/CockpitOverlay';
 import FloatingAstronaut from '../components/FloatingAstronaut';
 import { EarthBackground } from '../components/background';
-import { CaptainsLogSidebar, Projects } from '../components/hud';
+import { CaptainsLogSidebar, Projects, ControlPanel } from '../components/hud';
 import Terminal from '../components/hud/Terminal';
 import RadioPlayer from '../components/RadioPlayer';
 import { getReposWithReadme } from '../lib/github';
@@ -36,6 +36,7 @@ export default async function Home() {
           />
 
           <CockpitOverlay />
+          <ControlPanel />
           {/* Main Content Grid */}
           <section className="w-full max-w-7xl grid grid-cols-3 lg:grid-cols-3 gap-8 sm:g bg-center">
 

--- a/portfolio/src/components/RadioPlayer.tsx
+++ b/portfolio/src/components/RadioPlayer.tsx
@@ -128,7 +128,7 @@ export default function RadioPlayer() {
                     <ul className="flex flex-col gap-0.5 text-xs w-full">
                         {visibleStations.map((station, i) => {
                             // Map window index to real index
-                            let idx = (stationIndex - 1 + i + stations.length) % stations.length;
+                            const idx = (stationIndex - 1 + i + stations.length) % stations.length;
                             const isActive = idx === stationIndex;
                             return (
                                 <li

--- a/portfolio/src/components/background/Comets.tsx
+++ b/portfolio/src/components/background/Comets.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useRef } from 'react';
+import { useCosmicControl } from '@/lib/useCosmicControl';
 
 interface Comet {
   x: number;
@@ -12,10 +13,12 @@ interface Comet {
 }
 
 export default function CometCanvas() {
+  const { cometsEnabled } = useCosmicControl();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const cometsRef = useRef<Comet[]>([]);
 
   useEffect(() => {
+    if (!cometsEnabled) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
@@ -94,7 +97,9 @@ export default function CometCanvas() {
       clearInterval(interval);
       window.removeEventListener('resize', resize);
     };
-  }, []);
+  }, [cometsEnabled]);
+
+  if (!cometsEnabled) return null;
 
   return <canvas ref={canvasRef} className="absolute inset-0 w-full h-full pointer-events-none z-[-1]" />;
 }

--- a/portfolio/src/components/background/ShootingStars.tsx
+++ b/portfolio/src/components/background/ShootingStars.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState, JSX } from 'react';
+import { useCosmicControl } from '@/lib/useCosmicControl';
 
 /**
  * ShootingStars component
  * @param maxActive - Maximum number of shooting stars visible at once (default: 6)
  */
 export default function ShootingStars({ maxActive = 4 }: { maxActive?: number }) {
+  const { shootingStarsEnabled } = useCosmicControl();
   const [shootingStars, setShootingStars] = useState<JSX.Element[]>([]);
 
   useEffect(() => {
+    if (!shootingStarsEnabled) return;
     let timeoutId: number;
     function spawnStar() {
       const left = Math.random() * window.innerWidth;
@@ -30,7 +33,9 @@ export default function ShootingStars({ maxActive = 4 }: { maxActive?: number })
     }
     spawnStar();
     return () => clearTimeout(timeoutId);
-  }, [maxActive]);
+  }, [maxActive, shootingStarsEnabled]);
+
+  if (!shootingStarsEnabled) return null;
 
   return <>{shootingStars}</>;
 } 

--- a/portfolio/src/components/background/SpaceBackground.tsx
+++ b/portfolio/src/components/background/SpaceBackground.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { JSX, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { SpinningEarth } from './Earth';
 import CometCanvas from './Comets';
 import ShootingStars from './ShootingStars';
+import { useCosmicControl } from '@/lib/useCosmicControl';
 
 interface Star {
   id: number;
@@ -15,14 +16,15 @@ interface Star {
 }
 
 export default function Background() {
+  const { starLayerCount } = useCosmicControl();
   const [stars, setStars] = useState<Star[]>([]);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const earthRef = useRef<HTMLImageElement>(null);
 
-  // Generate stars on mount
+  // Generate stars on mount or when star layer count changes
   useEffect(() => {
     const generated: Star[] = [];
-    const layers = 3;
+    const layers = starLayerCount;
     const starsPerLayer = 70;
     const colors = ["#ffffff", "#aaddff", "#ffd1a4", "#c9b3ff", "#99e0ff", "#ffeedd"];
 
@@ -40,7 +42,7 @@ export default function Background() {
       }
     }
     setStars(generated);
-  }, []);
+  }, [starLayerCount]);
 
 
   useEffect(() => {
@@ -81,7 +83,7 @@ export default function Background() {
             transition: 'transform 0.05s linear',
           }}
         >
-          {[1, 2, 3].map((layer) => (
+          {Array.from({ length: starLayerCount }, (_, i) => i + 1).map((layer) => (
             <div
               key={layer}
               className="absolute inset-0"

--- a/portfolio/src/components/hud/ControlPanel.tsx
+++ b/portfolio/src/components/hud/ControlPanel.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useCosmicControl } from '@/lib/useCosmicControl';
+import ControlRow from './ControlRow';
+
+export default function ControlPanel() {
+  const { cometsEnabled, shootingStarsEnabled, starLayerCount, set } = useCosmicControl();
+
+  return (
+    <div className="hud-panel absolute top-16 right-4 w-80 z-50 shadow-xl bg-neutral-900/80 backdrop-blur border border-cyan-500 rounded-xl">
+      <h2 className="text-cyan-300 text-lg font-bold px-4 pt-3 pb-2">🛠 Scene Control</h2>
+
+      <ControlRow
+        label="Comets"
+        value={cometsEnabled}
+        onChange={(v: boolean) => set({ cometsEnabled: v })}
+      />
+      <ControlRow
+        label="Shooting Stars"
+        value={shootingStarsEnabled}
+        onChange={(v: boolean) => set({ shootingStarsEnabled: v })}
+      />
+      <ControlRow
+        label="Star Layers"
+        value={starLayerCount}
+        onChange={(v: number) => set({ starLayerCount: +v })}
+        step={1}
+      />
+    </div>
+  );
+}

--- a/portfolio/src/components/hud/ControlRow.tsx
+++ b/portfolio/src/components/hud/ControlRow.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { useState } from 'react';
+
+export default function ControlRow<T extends number | string | boolean>({
+  label,
+  value,
+  onChange,
+  step = 1,
+  formatter = (v: T) => String(v),
+}: {
+  label: string;
+  value: T;
+  onChange: (v: T) => void;
+  step?: number;
+  formatter?: (v: T) => string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [temp, setTemp] = useState(value.toString());
+
+  const toggleBool = () => onChange(!value as T);
+
+  return (
+    <div className="flex items-center justify-between px-4 py-2 border-b border-cyan-700/20 text-cyan-300 font-mono text-sm">
+      <span>{label}</span>
+      <div className="flex items-center gap-2">
+        {typeof value === 'boolean' ? (
+          <button
+            className="px-2 py-1 border border-cyan-500 rounded hover:bg-cyan-700/30"
+            onClick={toggleBool}
+          >
+            {value ? 'On' : 'Off'}
+          </button>
+        ) : (
+          <>
+            <button onClick={() => onChange(((value as number) - step) as T)}>-</button>
+            {editing ? (
+              <input
+                autoFocus
+                value={temp}
+                onChange={(e) => setTemp(e.target.value)}
+                onBlur={() => {
+                  onChange(isNaN(+temp) ? (temp as unknown as T) : ((+temp) as T));
+                  setEditing(false);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    onChange(isNaN(+temp) ? (temp as unknown as T) : ((+temp) as T));
+                    setEditing(false);
+                  }
+                }}
+                className="bg-transparent border border-cyan-400 px-1 text-right w-16"
+              />
+            ) : (
+              <span
+                onClick={() => setEditing(true)}
+                className="px-2 py-1 border border-cyan-500 rounded cursor-pointer hover:underline text-right w-16 text-cyan-100"
+              >
+                {formatter(value)}
+              </span>
+            )}
+            <button onClick={() => onChange(((value as number) + step) as T)}>+</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/portfolio/src/components/hud/index.ts
+++ b/portfolio/src/components/hud/index.ts
@@ -1,4 +1,5 @@
 import CaptainsLogSidebar from "./CaptainsLogSidebar";
 import Projects from "./Projects";
+import ControlPanel from "./ControlPanel";
 
-export { CaptainsLogSidebar, Projects }
+export { CaptainsLogSidebar, Projects, ControlPanel };

--- a/portfolio/src/lib/useCosmicControl.ts
+++ b/portfolio/src/lib/useCosmicControl.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+type CosmicControl = {
+  cometsEnabled: boolean;
+  shootingStarsEnabled: boolean;
+  starLayerCount: number;
+  set: (partial: Partial<CosmicControl>) => void;
+};
+
+export const useCosmicControl = create<CosmicControl>((set) => ({
+  cometsEnabled: true,
+  shootingStarsEnabled: true,
+  starLayerCount: 3,
+  set: (partial) => set(partial),
+}));


### PR DESCRIPTION
## Summary
- manage cosmic effects with Zustand store
- create reusable ControlRow component
- add ControlPanel HUD for comets, shooting stars, and star layers
- update space scene components to respect settings
- mount ControlPanel in main page
- adjust radio player lint issue

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_687712b62a648320951dd9eb4ccfce31