### PR TITLE
Add Earth scanning hover HUD

### DIFF
--- a/portfolio/src/components/background/Earth/EarthWithLayers.tsx
+++ b/portfolio/src/components/background/Earth/EarthWithLayers.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import React, { useRef } from "react";
-import { useFrame } from "@react-three/fiber";
+import { useFrame, ThreeEvent } from "@react-three/fiber";
 import { useTexture } from "@react-three/drei";
 import * as THREE from "three";
 import GlowSphere from "./GlowSphere";
+import ScanSweep from "./ScanSweep";
 
-export default function EarthWithLayers() {
+interface Props {
+  onPointerOver?: (e: ThreeEvent<PointerEvent>) => void;
+  onPointerOut?: (e: ThreeEvent<PointerEvent>) => void;
+  onPointerMove?: (e: ThreeEvent<PointerEvent>) => void;
+  scanning?: boolean;
+}
+export default function EarthWithLayers({ onPointerOver, onPointerOut, onPointerMove, scanning }: Props) {
     const earthRef = useRef<THREE.Mesh>(null);
     const cloudsRef = useRef<THREE.Mesh>(null);
 
@@ -23,9 +30,10 @@ export default function EarthWithLayers() {
     });
 
     return (
-        <group rotation={[0.41, 0, 0]}>
+        <group rotation={[0.41, 0, 0]} onPointerOver={onPointerOver} onPointerOut={onPointerOut} onPointerMove={onPointerMove}>
             {/* Glow effect around the Earth */}
             <GlowSphere />
+            <ScanSweep active={!!scanning} />
 
             {/* Cloud layer */}
             <mesh ref={cloudsRef}>

--- a/portfolio/src/components/background/Earth/ScanSweep.tsx
+++ b/portfolio/src/components/background/Earth/ScanSweep.tsx
@@ -1,0 +1,22 @@
+"use client";
+import React, { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+export default function ScanSweep({ active }: { active: boolean }) {
+  const ref = useRef<THREE.Mesh>(null);
+
+  useFrame(({ clock }) => {
+    if (ref.current && active) {
+      ref.current.rotation.y = clock.getElapsedTime() * 2;
+    }
+  });
+
+  if (!active) return null;
+  return (
+    <mesh ref={ref} rotation={[0, 0, 0]}>
+      <ringGeometry args={[1.05, 1.08, 64]} />
+      <meshBasicMaterial color="#38bdf8" transparent opacity={0.5} />
+    </mesh>
+  );
+}

--- a/portfolio/src/components/background/Earth/SpinningEarth.tsx
+++ b/portfolio/src/components/background/Earth/SpinningEarth.tsx
@@ -4,6 +4,9 @@ import React, { Suspense } from "react";
 import { Canvas } from "@react-three/fiber";
 import { Stars, OrbitControls } from "@react-three/drei";
 import EarthWithLayers from "./EarthWithLayers";
+import useHoverScan from "../../../hooks/useHoverScan";
+import ScanOverlay from "../../hud/ScanOverlay";
+import RingOverlay from "../../hud/RingOverlay";
 
 
 type Offset = {
@@ -16,6 +19,7 @@ interface SpinningEarthProps {
 }
 
 export default function SpinningEarth({ offset }: SpinningEarthProps) {
+    const scan = useHoverScan();
     return (
         <div
             className="fixed inset-0 pointer-events-none z-0"
@@ -26,7 +30,7 @@ export default function SpinningEarth({ offset }: SpinningEarthProps) {
                 top: "-25vh",         // Center vertically
             }}
         >
-            <Canvas camera={{ position: [0, -0.2, 2.2], fov: 45 }}
+            <Canvas className="pointer-events-auto" camera={{ position: [0, -0.2, 2.2], fov: 45 }}
 
                 onCreated={({ camera }) => {
                     camera.layers.enable(0); // default
@@ -45,13 +49,18 @@ export default function SpinningEarth({ offset }: SpinningEarthProps) {
                             0,
                         ]}
                     >
-                        <EarthWithLayers />
+                        <EarthWithLayers
+                            {...scan.eventHandlers}
+                            scanning={scan.isHovering && !scan.completed}
+                        />
                     </group>
 
                     <Stars radius={100} depth={500} count={1000} factor={6} />
                 </Suspense>
                 <OrbitControls enableZoom={false} autoRotate autoRotateSpeed={0.03} />
             </Canvas>
+            <ScanOverlay progress={scan.progress} position={scan.position} visible={scan.isHovering && !scan.completed} />
+            <RingOverlay visible={scan.completed} />
         </div>
     );
 }

--- a/portfolio/src/components/hud/RingOverlay.tsx
+++ b/portfolio/src/components/hud/RingOverlay.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React from "react";
+
+interface Props {
+  visible: boolean;
+}
+
+export default function RingOverlay({ visible }: Props) {
+  if (!visible) return null;
+  const ticks = Array.from({ length: 36 });
+  return (
+    <div className="pointer-events-none absolute inset-0 flex items-center justify-center z-40">
+      <svg viewBox="0 0 100 100" className="w-64 h-64 text-accent">
+        <g transform="translate(50 50)">
+          <circle cx="0" cy="0" r="45" fill="none" stroke="currentColor" strokeWidth="0.5" className="opacity-70" />
+          {ticks.map((_, i) => (
+            <line key={i} x1="0" y1="-45" x2="0" y2="-41" stroke="currentColor" strokeWidth="0.5" transform={`rotate(${i * 10})`} />
+          ))}
+          <line x1="0" y1="-45" x2="0" y2="-60" stroke="currentColor" strokeWidth="0.5" />
+          <text x="0" y="-65" fontSize="5" fill="currentColor" textAnchor="middle">
+            Earth
+          </text>
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/portfolio/src/components/hud/ScanOverlay.tsx
+++ b/portfolio/src/components/hud/ScanOverlay.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { motion } from "framer-motion";
+
+interface Props {
+  progress: number;
+  position: { x: number; y: number };
+  visible: boolean;
+}
+
+export default function ScanOverlay({ progress, position, visible }: Props) {
+  if (!visible) return null;
+  return (
+    <div
+      className="fixed pointer-events-none z-50 -translate-x-1/2 -translate-y-1/2"
+      style={{ left: position.x, top: position.y }}
+    >
+      <div className="bg-neutral-800/80 text-primaryText text-xs font-mono p-2 rounded shadow-lg w-28">
+        <motion.div
+          className="h-1 bg-accent mb-1"
+          initial={{ width: 0 }}
+          animate={{ width: `${progress}%` }}
+          transition={{ ease: "linear", duration: 0.1 }}
+        />
+        <div className="text-center tracking-widest">SCANNING</div>
+      </div>
+    </div>
+  );
+}

--- a/portfolio/src/components/hud/index.ts
+++ b/portfolio/src/components/hud/index.ts
@@ -2,5 +2,7 @@ import CaptainsLogSidebar from "./CaptainsLogSidebar";
 import Projects from "./Projects";
 import Terminal from "./Terminal";
 import RadioPlayer from "./RadioPlayer";
+import ScanOverlay from "./ScanOverlay";
+import RingOverlay from "./RingOverlay";
 
-export { CaptainsLogSidebar, Projects, Terminal, RadioPlayer }
+export { CaptainsLogSidebar, Projects, Terminal, RadioPlayer, ScanOverlay, RingOverlay };

--- a/portfolio/src/hooks/useHoverScan.ts
+++ b/portfolio/src/hooks/useHoverScan.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+
+interface HoverState {
+  eventHandlers: {
+    onPointerOver: () => void;
+    onPointerOut: () => void;
+    onPointerMove: (e: PointerEvent) => void;
+  };
+  progress: number;
+  position: { x: number; y: number };
+  isHovering: boolean;
+  completed: boolean;
+}
+
+export default function useHoverScan(duration = 2000): HoverState {
+  const [isHovering, setHovering] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [completed, setCompleted] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    let raf: number;
+    if (isHovering) {
+      const start = performance.now();
+      const loop = (now: number) => {
+        const pct = Math.min((now - start) / duration, 1);
+        setProgress(pct * 100);
+        if (pct < 1) {
+          raf = requestAnimationFrame(loop);
+        } else {
+          setCompleted(true);
+        }
+      };
+      raf = requestAnimationFrame(loop);
+    } else {
+      setProgress(0);
+      setCompleted(false);
+    }
+    return () => cancelAnimationFrame(raf);
+  }, [isHovering, duration]);
+
+  const onPointerOver = () => setHovering(true);
+  const onPointerOut = () => setHovering(false);
+  const onPointerMove = (e: PointerEvent) => {
+    setPosition({ x: e.clientX + 16, y: e.clientY + 16 });
+  };
+
+  return {
+    eventHandlers: { onPointerOver, onPointerOut, onPointerMove },
+    progress,
+    position,
+    isHovering,
+    completed,
+  };
+}

--- a/portfolio/src/hooks/useHoverScan.ts
+++ b/portfolio/src/hooks/useHoverScan.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 
+type PositionEvent = { clientX: number; clientY: number };
+
 interface HoverState {
   eventHandlers: {
     onPointerOver: () => void;
     onPointerOut: () => void;
-    onPointerMove: (e: PointerEvent) => void;
+    onPointerMove: (e: PositionEvent) => void;
   };
   progress: number;
   position: { x: number; y: number };
@@ -41,7 +43,7 @@ export default function useHoverScan(duration = 2000): HoverState {
 
   const onPointerOver = () => setHovering(true);
   const onPointerOut = () => setHovering(false);
-  const onPointerMove = (e: PointerEvent) => {
+  const onPointerMove = (e: PositionEvent) => {
     setPosition({ x: e.clientX + 16, y: e.clientY + 16 });
   };
 


### PR DESCRIPTION
## Summary
- create a `useHoverScan` hook for hover progress
- add ScanOverlay and RingOverlay HUD components
- add ScanSweep 3D effect for scanning sweep
- enable pointer events and scanning logic on Earth components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879b42bebe88320b2eb0cf1f6036513