### PR TITLE
feat: add snap-scrolling landing sections with parallax backdrop

### DIFF
--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -1,104 +1,13 @@
-import { CockpitOverlay, FloatingAstronaut, SpaceBackground } from '../components/background/';
-import { Logs, Projects } from '../components/hud';
-import { Terminal } from '../components/hud';
-import { RadioPlayer } from '../components/hud';
-import { getReposWithReadme } from '../api/github';
+import ParallaxSpace from "@/components/ParallaxSpace";
+import SnapScroller from "@/components/SnapScroller";
 
-
-export default async function Home() {
-  const repos = await getReposWithReadme();
+export default function Page() {
   return (
     <>
-      <div className="relative min-h-screen bg-neutral-950/60 backdrop-blur-md flex flex-col overflow-hidden">
-        <div className="absolute">
-          <SpaceBackground comets={10} starLayers={3} starsPerLayer={100} shootingStars={10} />
-        </div>
-        <main
-          id="main-content"
-          className="z-10 flex-1 flex flex-col items-center px-4 py-12 pt-60 relative pb-[220px]"
-        >
-          <FloatingAstronaut />
-
-          {/* Glass Texture/Effect */}
-          <div className="absolute inset-0 pointer-events-none z-0">
-            <div className="absolute inset-0 bg-gradient-to-tr from-cyan-900/9 to-transparent" />
-            <img
-              src="/glass-texture.png"
-              alt="glass texture"
-              className="w-full h-full object-cover opacity-10 mix-blend-screen fixed"
-            />
-          </div>
-
-          <img
-            src="/cockpit-hud.png"
-            alt="HUD Overlay"
-            className="hidden md:block fixed top-0 left-1/2 w-screen h-screen -translate-x-1/2 z-0 pointer-events-none"
-          />
-
-          <CockpitOverlay />
-
-
-          {/* Main Content Grid */}
-          <section className="w-full max-w-7xl grid grid-cols-3 lg:grid-cols-3 gap-8 sm:g bg-center relative pointer-events-none z-index-[-1]">
-            {/* On small screens, absolutely center the hero section */}
-            <div className="hidden lg:block lg:col-span-1" />
-            <div className="lg:col-span-1 lg:col-start-2">
-              {/* Hero Section */}
-              <section className="w-full max-w-2xl flex flex-col items-center text-center mb-12 fade-out-delayed
-                absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                lg:static lg:translate-x-0 lg:translate-y-0
-                ">
-                <img
-                  src="https://github.com/cameronloveland.png"
-                  alt="Cameron Loveland"
-                  className="w-20 h-20 rounded-full border-4 border-neutral-800 shadow mb-4 opacity-0 animate-fade-in delay-[100ms]"
-                />
-                <h1 className="text-3xl sm:text-4xl font-bold text-white mb-2 tracking-tight opacity-0 animate-fade-in delay-[300ms]">
-                  Cameron Loveland
-                </h1>
-                <p className="text-neutral-300 text-2xl opacity-0 animate-fade-in delay-[500ms]">
-                  Software Engineer
-                </p>
-                {/* <p className="text-neutral-400 italic text-xl mt-1 opacity-0 animate-fade-in delay-[700ms]">
-                  Welcome aboard — this is my interactive portfolio site.
-                </p> */}
-              </section>
-            </div>
-            <div className="hidden lg:block lg:col-span-1" />
-          </section>
-
-          {/* HUD ROW */}
-          <section className="w-full max-w-7xl grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-2 px-2 md:px-4 fixed bottom-0 md:bottom-8 z-20">
-            {/* Projects - 1/3 width on desktop */}
-            <div className="md:col-span-1 animate-slide-in-left pointer-events-auto">
-              <section className="perspective-[1200px]">
-                <div className="md:tilt-left">
-                  <Projects repos={repos} />
-                </div>
-              </section>
-            </div>
-            {/* Middle Section - 1/3 width, animates from bottom, no tilt */}
-            <div className="hidden md:block md:col-span-1 animate-slide-in-up pointer-events-auto">
-              <section className="perspective-[1200px]">
-                <div className="flex flex-col gap-2">
-                  <Terminal />
-                  <RadioPlayer />
-                </div>
-              </section>
-            </div>
-            {/* Captain's Log - 1/3 width */}
-            <div className="hidden md:block md:col-span-1 animate-slide-in-right pointer-events-auto">
-              <section className="perspective-[1200px]">
-                <div className="md:tilt-right">
-                  <Logs />
-                </div>
-              </section>
-            </div>
-          </section>
-
-        </main>
-      </div>
+      {/* fixed background layers */}
+      <ParallaxSpace />
+      {/* foreground UI */}
+      <SnapScroller />
     </>
   );
-
 }

--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -1,5 +1,6 @@
 import ParallaxSpace from "@/components/ParallaxSpace";
 import SnapScroller from "@/components/SnapScroller";
+import HomeLanding from "@/components/HomeLanding";
 
 export default function Page() {
   return (
@@ -7,7 +8,11 @@ export default function Page() {
       {/* fixed background layers */}
       <ParallaxSpace />
       {/* foreground UI */}
-      <SnapScroller />
+      <SnapScroller>
+        <HomeLanding />
+        <div>{/* second page content */}</div>
+        <div>{/* third page content */}</div>
+      </SnapScroller>
     </>
   );
 }

--- a/portfolio/src/components/HomeLanding.tsx
+++ b/portfolio/src/components/HomeLanding.tsx
@@ -1,0 +1,87 @@
+import { CockpitOverlay, FloatingAstronaut } from "@/components/background";
+import { Logs, Projects, Terminal, RadioPlayer } from "@/components/hud";
+import { getReposWithReadme } from "@/api/github";
+
+export default async function HomeLanding() {
+  const repos = await getReposWithReadme();
+  return (
+    <div className="relative min-h-screen bg-neutral-950/60 backdrop-blur-md flex flex-col overflow-hidden">
+      <main
+        id="main-content"
+        className="z-10 flex-1 flex flex-col items-center px-4 py-12 pt-60 relative pb-[220px]"
+      >
+        <FloatingAstronaut />
+
+        {/* Glass Texture/Effect */}
+        <div className="absolute inset-0 pointer-events-none z-0">
+          <div className="absolute inset-0 bg-gradient-to-tr from-cyan-900/9 to-transparent" />
+          <img
+            src="/glass-texture.png"
+            alt="glass texture"
+            className="w-full h-full object-cover opacity-10 mix-blend-screen fixed"
+          />
+        </div>
+
+        <img
+          src="/cockpit-hud.png"
+          alt="HUD Overlay"
+          className="hidden md:block fixed top-0 left-1/2 w-screen h-screen -translate-x-1/2 z-0 pointer-events-none"
+        />
+
+        <CockpitOverlay />
+
+        {/* Main Content Grid */}
+        <section className="w-full max-w-7xl grid grid-cols-3 gap-8 bg-center relative pointer-events-none">
+          <div className="hidden lg:block lg:col-span-1" />
+          <div className="lg:col-span-1 lg:col-start-2">
+            {/* Hero Section */}
+            <section className="w-full max-w-2xl flex flex-col items-center text-center mb-12 fade-out-delayed absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 lg:static lg:translate-x-0 lg:translate-y-0">
+              <img
+                src="https://github.com/cameronloveland.png"
+                alt="Cameron Loveland"
+                className="w-20 h-20 rounded-full border-4 border-neutral-800 shadow mb-4 opacity-0 animate-fade-in delay-[100ms]"
+              />
+              <h1 className="text-3xl sm:text-4xl font-bold text-white mb-2 tracking-tight opacity-0 animate-fade-in delay-[300ms]">
+                Cameron Loveland
+              </h1>
+              <p className="text-neutral-300 text-2xl opacity-0 animate-fade-in delay-[500ms]">
+                Software Engineer
+              </p>
+            </section>
+          </div>
+          <div className="hidden lg:block lg:col-span-1" />
+        </section>
+
+        {/* HUD ROW */}
+        <section className="w-full max-w-7xl grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-2 px-2 md:px-4 fixed bottom-0 md:bottom-8 z-20">
+          {/* Projects - 1/3 width on desktop */}
+          <div className="md:col-span-1 animate-slide-in-left pointer-events-auto">
+            <section className="perspective-[1200px]">
+              <div className="md:tilt-left">
+                <Projects repos={repos} />
+              </div>
+            </section>
+          </div>
+          {/* Middle Section - 1/3 width, animates from bottom, no tilt */}
+          <div className="hidden md:block md:col-span-1 animate-slide-in-up pointer-events-auto">
+            <section className="perspective-[1200px]">
+              <div className="flex flex-col gap-2">
+                <Terminal />
+                <RadioPlayer />
+              </div>
+            </section>
+          </div>
+          {/* Captain's Log - 1/3 width */}
+          <div className="hidden md:block md:col-span-1 animate-slide-in-right pointer-events-auto">
+            <section className="perspective-[1200px]">
+              <div className="md:tilt-right">
+                <Logs />
+              </div>
+            </section>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+

--- a/portfolio/src/components/ParallaxSpace.tsx
+++ b/portfolio/src/components/ParallaxSpace.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import { useEffect } from "react";
+import { SpaceBackground } from "./background";
 
 export default function ParallaxSpace() {
   // Ensure CSS var exists on mount
@@ -10,9 +11,9 @@ export default function ParallaxSpace() {
 
   return (
     <>
-      {/* Stars layer (replace with existing starfield if you have one) */}
-      <div className="fixed inset-0 -z-50 pointer-events-none bg-black">
-        {/* TODO: mount your Starfield component here instead of this div */}
+      {/* Stars layer */}
+      <div className="fixed inset-0 -z-50 pointer-events-none">
+        <SpaceBackground showEarth={false} />
       </div>
 
       {/* Earth layer */}
@@ -27,7 +28,7 @@ export default function ParallaxSpace() {
         }}
       >
         <Image
-          src="/images/earth.png"  // update to your asset
+          src="/textures/earth.png"
           alt=""
           width={1400}
           height={1400}

--- a/portfolio/src/components/ParallaxSpace.tsx
+++ b/portfolio/src/components/ParallaxSpace.tsx
@@ -1,0 +1,40 @@
+"use client";
+import Image from "next/image";
+import { useEffect } from "react";
+
+export default function ParallaxSpace() {
+  // Ensure CSS var exists on mount
+  useEffect(() => {
+    document.documentElement.style.setProperty("--scrollP", "0");
+  }, []);
+
+  return (
+    <>
+      {/* Stars layer (replace with existing starfield if you have one) */}
+      <div className="fixed inset-0 -z-50 pointer-events-none bg-black">
+        {/* TODO: mount your Starfield component here instead of this div */}
+      </div>
+
+      {/* Earth layer */}
+      <div
+        aria-hidden
+        className="fixed inset-0 -z-40 grid place-items-center pointer-events-none"
+        style={{
+          transform:
+            "translateY(calc(-220px * var(--scrollP))) scale(calc(1 - 0.05 * var(--scrollP)))",
+          opacity: "calc(1 - 0.65 * var(--scrollP))",
+          transition: "transform 0.1s linear, opacity 0.1s linear",
+        }}
+      >
+        <Image
+          src="/images/earth.png"  // update to your asset
+          alt=""
+          width={1400}
+          height={1400}
+          priority
+          className="select-none"
+        />
+      </div>
+    </>
+  );
+}

--- a/portfolio/src/components/ScrollDots.tsx
+++ b/portfolio/src/components/ScrollDots.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const ids = ["section-1", "section-2", "section-3"];
+
+export default function ScrollDots() {
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    const sections = ids
+      .map((id) => document.getElementById(id))
+      .filter(Boolean) as HTMLElement[];
+
+   const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            const idx = ids.indexOf(e.target.id);
+            if (idx !== -1) setActive(idx);
+          }
+        });
+      },
+      { root: null, threshold: 0.55 }
+    );
+    sections.forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
+  const jump = (i: number) => {
+    document.getElementById(ids[i])?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <div className="fixed right-6 top-1/2 -translate-y-1/2 z-50 flex flex-col gap-3">
+      {ids.map((_, i) => (
+        <button
+          key={i}
+          aria-label={`Go to section ${i + 1}`}
+          onClick={() => jump(i)}
+          className={[
+            "transition-all duration-200 rounded-full",
+            i === active ? "h-3 w-3 bg-cyan-300 ring ring-cyan-400" : "h-2 w-2 bg-cyan-200/50 hover:bg-cyan-200"
+          ].join(" ")}
+        />
+      ))}
+    </div>
+  );
+}

--- a/portfolio/src/components/SnapScroller.tsx
+++ b/portfolio/src/components/SnapScroller.tsx
@@ -1,8 +1,12 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, ReactNode, Children } from "react";
 import ScrollDots from "./ScrollDots";
 
-export default function SnapScroller() {
+interface SnapScrollerProps {
+  children: ReactNode;
+}
+
+export default function SnapScroller({ children }: SnapScrollerProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   // Drive CSS var --scrollP from progress between section 1 top and section 2 top
@@ -14,10 +18,8 @@ export default function SnapScroller() {
     const onScroll = () => {
       cancelAnimationFrame(raf);
       raf = requestAnimationFrame(() => {
-        const s1 = document.getElementById("section-1");
         const s2 = document.getElementById("section-2");
-        if (!s1 || !s2) return;
-        const top1 = s1.getBoundingClientRect().top;
+        if (!s2) return;
         const top2 = s2.getBoundingClientRect().top;
         const vh = window.innerHeight;
         // Normalize progress: when s1 is aligned (top=0) => 0, when s2 is aligned => 1
@@ -26,12 +28,14 @@ export default function SnapScroller() {
       });
     };
     onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
+    el.addEventListener("scroll", onScroll, { passive: true });
     return () => {
       cancelAnimationFrame(raf);
-      window.removeEventListener("scroll", onScroll);
+      el.removeEventListener("scroll", onScroll);
     };
   }, []);
+
+  const sections = Children.toArray(children);
 
   return (
     <>
@@ -40,17 +44,18 @@ export default function SnapScroller() {
         ref={ref}
         className="h-screen overflow-y-scroll snap-y snap-mandatory scroll-smooth"
       >
-        <section id="section-1" className="snap-start min-h-screen flex items-center justify-center">
-          {/* your hero/cockpit content (current state) */}
-        </section>
-
-        <section id="section-2" className="snap-start min-h-screen flex items-center justify-center">
-          {/* second page content */}
-        </section>
-
-        <section id="section-3" className="snap-start min-h-screen flex items-center justify-center">
-          {/* third page content */}
-        </section>
+        {sections.map((child, i) => (
+          <section
+            key={i}
+            id={`section-${i + 1}`}
+            className={
+              "snap-start min-h-screen" +
+              (i === 0 ? "" : " flex items-center justify-center")
+            }
+          >
+            {child}
+          </section>
+        ))}
       </div>
     </>
   );

--- a/portfolio/src/components/SnapScroller.tsx
+++ b/portfolio/src/components/SnapScroller.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useEffect, useRef } from "react";
+import ScrollDots from "./ScrollDots";
+
+export default function SnapScroller() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Drive CSS var --scrollP from progress between section 1 top and section 2 top
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    let raf = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        const s1 = document.getElementById("section-1");
+        const s2 = document.getElementById("section-2");
+        if (!s1 || !s2) return;
+        const top1 = s1.getBoundingClientRect().top;
+        const top2 = s2.getBoundingClientRect().top;
+        const vh = window.innerHeight;
+        // Normalize progress: when s1 is aligned (top=0) => 0, when s2 is aligned => 1
+        const progress = 1 - Math.min(1, Math.max(0, top2 / vh));
+        document.documentElement.style.setProperty("--scrollP", progress.toFixed(4));
+      });
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  return (
+    <>
+      <ScrollDots />
+      <div
+        ref={ref}
+        className="h-screen overflow-y-scroll snap-y snap-mandatory scroll-smooth"
+      >
+        <section id="section-1" className="snap-start min-h-screen flex items-center justify-center">
+          {/* your hero/cockpit content (current state) */}
+        </section>
+
+        <section id="section-2" className="snap-start min-h-screen flex items-center justify-center">
+          {/* second page content */}
+        </section>
+
+        <section id="section-3" className="snap-start min-h-screen flex items-center justify-center">
+          {/* third page content */}
+        </section>
+      </div>
+    </>
+  );
+}

--- a/portfolio/src/components/background/SpaceBackground.tsx
+++ b/portfolio/src/components/background/SpaceBackground.tsx
@@ -19,10 +19,16 @@ interface SpaceBackgroundProps {
   starLayers?: number;
   starsPerLayer?: number;
   shootingStars?: number;
+  showEarth?: boolean;
 }
 
-export default function SpaceBackground({ comets = 10, starLayers = 3, starsPerLayer = 100,
-  shootingStars = 10 }: SpaceBackgroundProps) {
+export default function SpaceBackground({
+  comets = 10,
+  starLayers = 3,
+  starsPerLayer = 100,
+  shootingStars = 10,
+  showEarth = true,
+}: SpaceBackgroundProps) {
   const [stars, setStars] = useState<Star[]>([]);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const earthRef = useRef<HTMLImageElement>(null);
@@ -122,7 +128,9 @@ export default function SpaceBackground({ comets = 10, starLayers = 3, starsPerL
           ))}
 
         </div>
-        <SpinningEarth offset={{ x: offset.x * 0.05, y: offset.y * 0.05 }} />
+        {showEarth && (
+          <SpinningEarth offset={{ x: offset.x * 0.05, y: offset.y * 0.05 }} />
+        )}
         <ShootingStars count={shootingStars} />
       </div >
     </div >

--- a/portfolio/src/styles/theme.css
+++ b/portfolio/src/styles/theme.css
@@ -3,6 +3,12 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --scrollP: 0;
+}
+
+html,
+body {
+  height: 100%;
 }
 
 @theme inline {
@@ -150,3 +156,7 @@ body {
     top: 100%;
   }
 }
+
+/* optional: hide scrollbar on webkit */
+.scrollbar-none::-webkit-scrollbar { display: none; }
+.scrollbar-none { -ms-overflow-style: none; scrollbar-width: none; }


### PR DESCRIPTION
## Summary
- implement snap-scrolling sections with scroll-driven parallax variable
- add fixed starfield and parallax earth layers
- add sidebar dot navigation with IntersectionObserver

## Testing
- `npx next build --no-lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68abb4119e3083208efd4aa7e65b937f