### PR TITLE
Refactor portfolio into modern landing site

### DIFF
--- a/portfolio/src/app/layout.tsx
+++ b/portfolio/src/app/layout.tsx
@@ -1,17 +1,13 @@
 import type { Metadata } from "next";
 import "../styles/theme.css";
 import "../styles/fonts.css";
-import "../styles/radioPlayer.css";
-import "../styles/animations.css";
-import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import Header from "../components/Header";
-import { Footer } from "../components/Footer";
-import ParallaxHandler from "../components/ParallaxHandler";
+import Footer from "../components/Footer";
 
 export const metadata: Metadata = {
   title: "Portfolio | Cameron Loveland",
-  description: "Beefed up GitHub Pages portfolio with interactive elements and animations.",
+  description: "Cameron Loveland is a software engineer who builds thoughtful, user-first experiences.",
 };
 
 export default function RootLayout({
@@ -24,15 +20,20 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="https://github.com/cameronloveland.png" />
       </head>
-      <body className="antialiased">
-        <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-cyan-500 text-black px-4 py-2 rounded z-50">
+      <body className="min-h-screen bg-white text-slate-900 antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-cyan"
+        >
           Skip to main content
         </a>
-        <ParallaxHandler>
+        <div className="flex min-h-screen flex-col" id="top">
           <Header />
-          <main className="flex-1">{children}</main>
+          <main id="main-content" className="flex-1">
+            {children}
+          </main>
           <Footer />
-        </ParallaxHandler>
+        </div>
       </body>
     </html>
   );

--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -1,13 +1,53 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { Card } from "../components/Card";
 
-const projects = [
+const cockpitDemoUrl = "/docs/index.html";
+
+interface Project {
+  title: string;
+  description: string;
+  href?: string;
+  tags?: string[];
+  preview?: ReactNode;
+  actions?: {
+    label: string;
+    href: string;
+    variant?: "primary" | "secondary";
+    external?: boolean;
+  }[];
+}
+
+const projects: Project[] = [
   {
     title: "Space Cockpit Demo",
     description:
       "An immersive Three.js experiment that simulates a pilot's control deck with layered instrumentation, lighting, and responsive controls.",
-    href: "/projects/space-cockpit",
     tags: ["Three.js", "React", "Postprocessing"],
+    preview: (
+      <div className="overflow-hidden rounded-2xl border border-slate-200 shadow-soft">
+        <iframe
+          src={cockpitDemoUrl}
+          title="Space cockpit live preview"
+          className="aspect-video w-full"
+          loading="lazy"
+          allowFullScreen
+        />
+      </div>
+    ),
+    actions: [
+      {
+        label: "Launch full demo",
+        href: cockpitDemoUrl,
+        external: true,
+        variant: "primary",
+      },
+      {
+        label: "Project details",
+        href: "/projects/space-cockpit",
+        variant: "secondary",
+      },
+    ],
   },
   {
     title: "Design Systems",
@@ -25,13 +65,13 @@ const projects = [
 
 export default function Home() {
   return (
-    <div className="bg-white">
-      <section className="mx-auto flex max-w-6xl flex-col gap-10 px-4 pb-20 pt-24 sm:px-6 sm:pt-32 lg:flex-row lg:items-center lg:justify-between" id="home">
+    <div className="bg-white text-brand-midnight">
+      <section className="mx-auto flex max-w-6xl flex-col gap-12 px-4 pb-20 pt-24 sm:px-6 sm:pt-32 lg:flex-row lg:items-center lg:justify-between" id="home">
         <div className="max-w-xl space-y-6">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Software Engineer</p>
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo">Software Engineer</p>
           <div className="space-y-4">
-            <h1 className="font-heading text-4xl font-semibold text-slate-900 sm:text-5xl">Cameron Loveland</h1>
-            <p className="text-lg leading-relaxed text-slate-600">
+            <h1 className="font-heading text-4xl font-semibold text-brand-midnight sm:text-5xl">Cameron Loveland</h1>
+            <p className="text-lg leading-relaxed text-slate-700">
               I design and build thoughtful digital experiences that balance craft with measurable impact. From UX foundations to
               performant front-end systems, I love turning complex ideas into intuitive products.
             </p>
@@ -39,37 +79,37 @@ export default function Home() {
           <div className="flex flex-wrap gap-3">
             <a
               href="#projects"
-              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              className="inline-flex items-center justify-center rounded-full bg-brand-midnight px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               Explore projects
             </a>
             <a
               href="#contact"
-              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-brand-midnight transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               Get in touch
             </a>
           </div>
         </div>
-        <div className="relative -mx-4 rounded-[2.5rem] bg-gradient-to-br from-brand-cyan/20 via-white to-brand-indigo/10 px-4 py-8 sm:-mx-0 sm:p-10 lg:w-1/2">
+        <div className="relative -mx-4 rounded-[2.5rem] bg-gradient-to-br from-white via-brand-cyan/10 to-brand-indigo/10 px-4 py-8 sm:-mx-0 sm:p-10 lg:w-1/2">
           <div className="space-y-6">
-            <h2 className="font-heading text-xl font-semibold text-slate-900">About</h2>
-            <p className="text-base leading-relaxed text-slate-600">
+            <h2 className="font-heading text-xl font-semibold text-brand-midnight">About</h2>
+            <p className="text-base leading-relaxed text-slate-700">
               I bring a decade of experience building products for startups and global brands alike. My work spans design systems,
               creative tooling, and performance-focused engineering. I believe in delivering reliable software that feels as polished
               as it is practical.
             </p>
             <div className="grid grid-cols-2 gap-4 text-sm font-semibold text-slate-700 sm:grid-cols-3">
               <div className="rounded-2xl bg-white px-4 py-3 shadow-soft">
-                <p className="text-xs uppercase tracking-wide text-slate-400">Focus</p>
+                <p className="text-xs uppercase tracking-wide text-slate-500">Focus</p>
                 <p>Product Engineering</p>
               </div>
               <div className="rounded-2xl bg-white px-4 py-3 shadow-soft">
-                <p className="text-xs uppercase tracking-wide text-slate-400">Strength</p>
+                <p className="text-xs uppercase tracking-wide text-slate-500">Strength</p>
                 <p>Design Systems</p>
               </div>
               <div className="rounded-2xl bg-white px-4 py-3 shadow-soft sm:col-span-1">
-                <p className="text-xs uppercase tracking-wide text-slate-400">Location</p>
+                <p className="text-xs uppercase tracking-wide text-slate-500">Location</p>
                 <p>Seattle, WA</p>
               </div>
             </div>
@@ -80,15 +120,24 @@ export default function Home() {
       <section id="projects" className="bg-slate-50 py-20">
         <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 sm:px-6">
           <div className="space-y-3">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Projects</p>
-            <h2 className="font-heading text-3xl font-semibold text-slate-900 sm:text-4xl">Selected work</h2>
-            <p className="max-w-2xl text-base text-slate-600">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo">Projects</p>
+            <h2 className="font-heading text-3xl font-semibold text-brand-midnight sm:text-4xl">Selected work</h2>
+            <p className="max-w-2xl text-base text-slate-700">
               A few highlights from recent projects that showcase product thinking, interaction design, and technical execution.
             </p>
           </div>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {projects.map((project) => (
-              <Card key={project.title} title={project.title} description={project.description} href={project.href} tags={project.tags} />
+              <Card
+                key={project.title}
+                title={project.title}
+                description={project.description}
+                href={project.href}
+                tags={project.tags}
+                actions={project.actions}
+              >
+                {project.preview}
+              </Card>
             ))}
           </div>
         </div>
@@ -97,29 +146,29 @@ export default function Home() {
       <section id="contact" className="py-20">
         <div className="mx-auto flex max-w-3xl flex-col gap-8 px-4 text-center sm:px-6">
           <div className="space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Contact</p>
-            <h2 className="font-heading text-3xl font-semibold text-slate-900 sm:text-4xl">Let’s build something together</h2>
-            <p className="text-base leading-relaxed text-slate-600">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo">Contact</p>
+            <h2 className="font-heading text-3xl font-semibold text-brand-midnight sm:text-4xl">Let’s build something together</h2>
+            <p className="text-base leading-relaxed text-slate-700">
               Whether you’re building a new product or refining an existing experience, I’d love to collaborate.
             </p>
           </div>
           <div className="flex flex-col items-center gap-4 text-sm font-semibold text-slate-700">
             <Link
               href="mailto:cameron@loveland.dev"
-              className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              className="inline-flex items-center gap-2 rounded-full bg-brand-midnight px-6 py-3 text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               cameron@loveland.dev
             </Link>
             <div className="flex flex-wrap items-center justify-center gap-4 text-slate-600">
               <Link
                 href="https://github.com/cameronloveland"
-                className="rounded-full px-4 py-2 transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="rounded-full px-4 py-2 font-semibold text-brand-midnight transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 GitHub
               </Link>
               <Link
                 href="https://www.linkedin.com/in/cameronloveland/"
-                className="rounded-full px-4 py-2 transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="rounded-full px-4 py-2 font-semibold text-brand-midnight transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 LinkedIn
               </Link>

--- a/portfolio/src/app/page.tsx
+++ b/portfolio/src/app/page.tsx
@@ -1,104 +1,132 @@
-import { CockpitOverlay, FloatingAstronaut, SpaceBackground } from '../components/background/';
-import { Logs, Projects } from '../components/hud';
-import { Terminal } from '../components/hud';
-import { RadioPlayer } from '../components/hud';
-import { getReposWithReadme } from '../api/github';
+import Link from "next/link";
+import { Card } from "../components/Card";
 
+const projects = [
+  {
+    title: "Space Cockpit Demo",
+    description:
+      "An immersive Three.js experiment that simulates a pilot's control deck with layered instrumentation, lighting, and responsive controls.",
+    href: "/projects/space-cockpit",
+    tags: ["Three.js", "React", "Postprocessing"],
+  },
+  {
+    title: "Design Systems",
+    description:
+      "Establishing accessible component libraries with scalable design tokens and tooling that help teams ship with confidence.",
+    tags: ["Design Ops", "Accessibility", "Storybook"],
+  },
+  {
+    title: "Product Engineering",
+    description:
+      "Collaborating with cross-functional partners to build high-impact product experiences across web and mobile platforms.",
+    tags: ["TypeScript", "Next.js", "Mobile"],
+  },
+];
 
-export default async function Home() {
-  const repos = await getReposWithReadme();
+export default function Home() {
   return (
-    <>
-      <div className="relative min-h-screen bg-neutral-950/60 backdrop-blur-md flex flex-col overflow-hidden">
-        <div className="absolute">
-          <SpaceBackground comets={10} starLayers={3} starsPerLayer={100} shootingStars={10} />
-        </div>
-        <main
-          id="main-content"
-          className="z-10 flex-1 flex flex-col items-center px-4 py-12 pt-60 relative pb-[220px]"
-        >
-          <FloatingAstronaut />
-
-          {/* Glass Texture/Effect */}
-          <div className="absolute inset-0 pointer-events-none z-0">
-            <div className="absolute inset-0 bg-gradient-to-tr from-cyan-900/9 to-transparent" />
-            <img
-              src="/glass-texture.png"
-              alt="glass texture"
-              className="w-full h-full object-cover opacity-10 mix-blend-screen fixed"
-            />
+    <div className="bg-white">
+      <section className="mx-auto flex max-w-6xl flex-col gap-10 px-4 pb-20 pt-24 sm:px-6 sm:pt-32 lg:flex-row lg:items-center lg:justify-between" id="home">
+        <div className="max-w-xl space-y-6">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Software Engineer</p>
+          <div className="space-y-4">
+            <h1 className="font-heading text-4xl font-semibold text-slate-900 sm:text-5xl">Cameron Loveland</h1>
+            <p className="text-lg leading-relaxed text-slate-600">
+              I design and build thoughtful digital experiences that balance craft with measurable impact. From UX foundations to
+              performant front-end systems, I love turning complex ideas into intuitive products.
+            </p>
           </div>
-
-          <img
-            src="/cockpit-hud.png"
-            alt="HUD Overlay"
-            className="hidden md:block fixed top-0 left-1/2 w-screen h-screen -translate-x-1/2 z-0 pointer-events-none"
-          />
-
-          <CockpitOverlay />
-
-
-          {/* Main Content Grid */}
-          <section className="w-full max-w-7xl grid grid-cols-3 lg:grid-cols-3 gap-8 sm:g bg-center relative pointer-events-none z-index-[-1]">
-            {/* On small screens, absolutely center the hero section */}
-            <div className="hidden lg:block lg:col-span-1" />
-            <div className="lg:col-span-1 lg:col-start-2">
-              {/* Hero Section */}
-              <section className="w-full max-w-2xl flex flex-col items-center text-center mb-12 fade-out-delayed
-                absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                lg:static lg:translate-x-0 lg:translate-y-0
-                ">
-                <img
-                  src="https://github.com/cameronloveland.png"
-                  alt="Cameron Loveland"
-                  className="w-20 h-20 rounded-full border-4 border-neutral-800 shadow mb-4 opacity-0 animate-fade-in delay-[100ms]"
-                />
-                <h1 className="text-3xl sm:text-4xl font-bold text-white mb-2 tracking-tight opacity-0 animate-fade-in delay-[300ms]">
-                  Cameron Loveland
-                </h1>
-                <p className="text-neutral-300 text-2xl opacity-0 animate-fade-in delay-[500ms]">
-                  Software Engineer
-                </p>
-                {/* <p className="text-neutral-400 italic text-xl mt-1 opacity-0 animate-fade-in delay-[700ms]">
-                  Welcome aboard — this is my interactive portfolio site.
-                </p> */}
-              </section>
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="#projects"
+              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            >
+              Explore projects
+            </a>
+            <a
+              href="#contact"
+              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            >
+              Get in touch
+            </a>
+          </div>
+        </div>
+        <div className="relative -mx-4 rounded-[2.5rem] bg-gradient-to-br from-brand-cyan/20 via-white to-brand-indigo/10 px-4 py-8 sm:-mx-0 sm:p-10 lg:w-1/2">
+          <div className="space-y-6">
+            <h2 className="font-heading text-xl font-semibold text-slate-900">About</h2>
+            <p className="text-base leading-relaxed text-slate-600">
+              I bring a decade of experience building products for startups and global brands alike. My work spans design systems,
+              creative tooling, and performance-focused engineering. I believe in delivering reliable software that feels as polished
+              as it is practical.
+            </p>
+            <div className="grid grid-cols-2 gap-4 text-sm font-semibold text-slate-700 sm:grid-cols-3">
+              <div className="rounded-2xl bg-white px-4 py-3 shadow-soft">
+                <p className="text-xs uppercase tracking-wide text-slate-400">Focus</p>
+                <p>Product Engineering</p>
+              </div>
+              <div className="rounded-2xl bg-white px-4 py-3 shadow-soft">
+                <p className="text-xs uppercase tracking-wide text-slate-400">Strength</p>
+                <p>Design Systems</p>
+              </div>
+              <div className="rounded-2xl bg-white px-4 py-3 shadow-soft sm:col-span-1">
+                <p className="text-xs uppercase tracking-wide text-slate-400">Location</p>
+                <p>Seattle, WA</p>
+              </div>
             </div>
-            <div className="hidden lg:block lg:col-span-1" />
-          </section>
+          </div>
+        </div>
+      </section>
 
-          {/* HUD ROW */}
-          <section className="w-full max-w-7xl grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-2 px-2 md:px-4 fixed bottom-0 md:bottom-8 z-20">
-            {/* Projects - 1/3 width on desktop */}
-            <div className="md:col-span-1 animate-slide-in-left pointer-events-auto">
-              <section className="perspective-[1200px]">
-                <div className="md:tilt-left">
-                  <Projects repos={repos} />
-                </div>
-              </section>
-            </div>
-            {/* Middle Section - 1/3 width, animates from bottom, no tilt */}
-            <div className="hidden md:block md:col-span-1 animate-slide-in-up pointer-events-auto">
-              <section className="perspective-[1200px]">
-                <div className="flex flex-col gap-2">
-                  <Terminal />
-                  <RadioPlayer />
-                </div>
-              </section>
-            </div>
-            {/* Captain's Log - 1/3 width */}
-            <div className="hidden md:block md:col-span-1 animate-slide-in-right pointer-events-auto">
-              <section className="perspective-[1200px]">
-                <div className="md:tilt-right">
-                  <Logs />
-                </div>
-              </section>
-            </div>
-          </section>
+      <section id="projects" className="bg-slate-50 py-20">
+        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 sm:px-6">
+          <div className="space-y-3">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Projects</p>
+            <h2 className="font-heading text-3xl font-semibold text-slate-900 sm:text-4xl">Selected work</h2>
+            <p className="max-w-2xl text-base text-slate-600">
+              A few highlights from recent projects that showcase product thinking, interaction design, and technical execution.
+            </p>
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {projects.map((project) => (
+              <Card key={project.title} title={project.title} description={project.description} href={project.href} tags={project.tags} />
+            ))}
+          </div>
+        </div>
+      </section>
 
-        </main>
-      </div>
-    </>
+      <section id="contact" className="py-20">
+        <div className="mx-auto flex max-w-3xl flex-col gap-8 px-4 text-center sm:px-6">
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Contact</p>
+            <h2 className="font-heading text-3xl font-semibold text-slate-900 sm:text-4xl">Let’s build something together</h2>
+            <p className="text-base leading-relaxed text-slate-600">
+              Whether you’re building a new product or refining an existing experience, I’d love to collaborate.
+            </p>
+          </div>
+          <div className="flex flex-col items-center gap-4 text-sm font-semibold text-slate-700">
+            <Link
+              href="mailto:cameron@loveland.dev"
+              className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            >
+              cameron@loveland.dev
+            </Link>
+            <div className="flex flex-wrap items-center justify-center gap-4 text-slate-600">
+              <Link
+                href="https://github.com/cameronloveland"
+                className="rounded-full px-4 py-2 transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              >
+                GitHub
+              </Link>
+              <Link
+                href="https://www.linkedin.com/in/cameronloveland/"
+                className="rounded-full px-4 py-2 transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              >
+                LinkedIn
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
   );
-
 }

--- a/portfolio/src/app/projects/space-cockpit/page.tsx
+++ b/portfolio/src/app/projects/space-cockpit/page.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Space Cockpit Demo | Cameron Loveland",
+  description:
+    "Explore the interactive 3D cockpit demo showcasing immersive UI design, layered instrumentation, and real-time effects.",
+};
+
+const cockpitDemoUrl = "/docs/index.html";
+
+export default function SpaceCockpitPage() {
+  return (
+    <div className="bg-white">
+      <section className="mx-auto flex max-w-5xl flex-col gap-8 px-4 pb-16 pt-24 sm:px-6 sm:pt-32">
+        <div className="space-y-6 text-left">
+          <Link
+            href="/"
+            className="inline-flex w-fit items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          >
+            ← Back to portfolio
+          </Link>
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Project</p>
+            <h1 className="font-heading text-4xl font-semibold text-slate-900 sm:text-5xl">Space Cockpit Demo</h1>
+            <p className="max-w-3xl text-base leading-relaxed text-slate-600">
+              This concept explores how cinematic UI patterns translate to the browser. The 3D cockpit layers real-time lighting,
+              post-processing, and spatial audio to create a focused command center experience for spaceflight simulation.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              href={cockpitDemoUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            >
+              Launch demo
+            </Link>
+            <Link
+              href="https://github.com/cameronloveland"
+              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            >
+              View more work
+            </Link>
+          </div>
+        </div>
+        <div className="overflow-hidden rounded-[2rem] border border-slate-200 shadow-soft">
+          <iframe
+            src={cockpitDemoUrl}
+            title="Space cockpit interactive demo"
+            className="aspect-video w-full"
+            loading="lazy"
+          />
+        </div>
+        <div className="space-y-4 text-base leading-relaxed text-slate-600">
+          <p>
+            Built with Three.js, React Three Fiber, and a layer of post-processing effects, the cockpit demonstrates how advanced
+            visual experiences can remain performant and accessible on the web. Every element—from depth-of-field to parallaxed UI
+            panels—responds to the user, creating a sense of immersion without sacrificing usability.
+          </p>
+          <p>
+            The project also informed broader design system work, inspiring motion principles and interaction patterns that now
+            appear across other product experiences.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/portfolio/src/app/projects/space-cockpit/page.tsx
+++ b/portfolio/src/app/projects/space-cockpit/page.tsx
@@ -11,19 +11,19 @@ const cockpitDemoUrl = "/docs/index.html";
 
 export default function SpaceCockpitPage() {
   return (
-    <div className="bg-white">
+    <div className="bg-white text-brand-midnight">
       <section className="mx-auto flex max-w-5xl flex-col gap-8 px-4 pb-16 pt-24 sm:px-6 sm:pt-32">
         <div className="space-y-6 text-left">
           <Link
             href="/"
-            className="inline-flex w-fit items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            className="inline-flex w-fit items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-midnight transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           >
             ← Back to portfolio
           </Link>
           <div className="space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo/80">Project</p>
-            <h1 className="font-heading text-4xl font-semibold text-slate-900 sm:text-5xl">Space Cockpit Demo</h1>
-            <p className="max-w-3xl text-base leading-relaxed text-slate-600">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-indigo">Project</p>
+            <h1 className="font-heading text-4xl font-semibold text-brand-midnight sm:text-5xl">Space Cockpit Demo</h1>
+            <p className="max-w-3xl text-base leading-relaxed text-slate-700">
               This concept explores how cinematic UI patterns translate to the browser. The 3D cockpit layers real-time lighting,
               post-processing, and spatial audio to create a focused command center experience for spaceflight simulation.
             </p>
@@ -33,13 +33,13 @@ export default function SpaceCockpitPage() {
               href={cockpitDemoUrl}
               target="_blank"
               rel="noreferrer noopener"
-              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              className="inline-flex items-center justify-center rounded-full bg-brand-midnight px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               Launch demo
             </Link>
             <Link
               href="https://github.com/cameronloveland"
-              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-brand-midnight transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               View more work
             </Link>
@@ -51,9 +51,10 @@ export default function SpaceCockpitPage() {
             title="Space cockpit interactive demo"
             className="aspect-video w-full"
             loading="lazy"
+            allowFullScreen
           />
         </div>
-        <div className="space-y-4 text-base leading-relaxed text-slate-600">
+        <div className="space-y-4 text-base leading-relaxed text-slate-700">
           <p>
             Built with Three.js, React Three Fiber, and a layer of post-processing effects, the cockpit demonstrates how advanced
             visual experiences can remain performant and accessible on the web. Every element—from depth-of-field to parallaxed UI

--- a/portfolio/src/components/Card.tsx
+++ b/portfolio/src/components/Card.tsx
@@ -8,16 +8,24 @@ interface CardProps {
   eyebrow?: string;
   tags?: string[];
   children?: ReactNode;
+  actions?: CardAction[];
 }
 
-export function Card({ title, description, href, eyebrow, tags, children }: CardProps) {
+export interface CardAction {
+  label: string;
+  href: string;
+  variant?: "primary" | "secondary";
+  external?: boolean;
+}
+
+export function Card({ title, description, href, eyebrow, tags, children, actions }: CardProps) {
   const content = (
-    <article className="flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-xl group-hover:-translate-y-1 group-hover:shadow-xl group-focus-visible:-translate-y-1 group-focus-visible:shadow-xl">
+    <article className="group flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-xl focus-within:-translate-y-1 focus-within:shadow-xl">
       <div className="space-y-4">
-        {eyebrow ? <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-indigo/70">{eyebrow}</p> : null}
+        {eyebrow ? <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-indigo">{eyebrow}</p> : null}
         <div className="space-y-2">
-          <h3 className="font-heading text-xl font-semibold text-slate-900">{title}</h3>
-          <p className="text-sm leading-relaxed text-slate-600">{description}</p>
+          <h3 className="font-heading text-xl font-semibold text-brand-midnight">{title}</h3>
+          <p className="text-sm leading-relaxed text-slate-700">{description}</p>
         </div>
         {tags && tags.length > 0 ? (
           <ul className="flex flex-wrap gap-2">
@@ -30,22 +38,32 @@ export function Card({ title, description, href, eyebrow, tags, children }: Card
         ) : null}
         {children}
       </div>
-      {href ? (
-        <p className="mt-6 text-sm font-semibold text-brand-cyan transition group-hover:text-brand-indigo group-focus-visible:text-brand-indigo">View project →</p>
-      ) : null}
+      <div className="mt-6 flex flex-wrap gap-3">
+        {actions?.map((action) => (
+          <Link
+            key={action.label}
+            href={action.href}
+            target={action.external ? "_blank" : undefined}
+            rel={action.external ? "noreferrer noopener" : undefined}
+            className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
+              action.variant === "primary"
+                ? "bg-brand-midnight text-white hover:bg-brand-indigo"
+                : "border border-slate-200 text-brand-midnight hover:border-brand-cyan hover:text-brand-indigo"
+            }`}
+          >
+            {action.label}
+          </Link>
+        ))}
+        {!actions?.length && href ? (
+          <Link
+            href={href}
+            className="inline-flex items-center justify-center rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-midnight transition hover:border-brand-cyan hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          >
+            View project →
+          </Link>
+        ) : null}
+      </div>
     </article>
   );
-
-  if (href) {
-    return (
-      <Link
-        href={href}
-        className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-      >
-        {content}
-      </Link>
-    );
-  }
-
   return content;
 }

--- a/portfolio/src/components/Card.tsx
+++ b/portfolio/src/components/Card.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+interface CardProps {
+  title: string;
+  description: string;
+  href?: string;
+  eyebrow?: string;
+  tags?: string[];
+  children?: ReactNode;
+}
+
+export function Card({ title, description, href, eyebrow, tags, children }: CardProps) {
+  const content = (
+    <article className="flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-xl group-hover:-translate-y-1 group-hover:shadow-xl group-focus-visible:-translate-y-1 group-focus-visible:shadow-xl">
+      <div className="space-y-4">
+        {eyebrow ? <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-indigo/70">{eyebrow}</p> : null}
+        <div className="space-y-2">
+          <h3 className="font-heading text-xl font-semibold text-slate-900">{title}</h3>
+          <p className="text-sm leading-relaxed text-slate-600">{description}</p>
+        </div>
+        {tags && tags.length > 0 ? (
+          <ul className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <li key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {children}
+      </div>
+      {href ? (
+        <p className="mt-6 text-sm font-semibold text-brand-cyan transition group-hover:text-brand-indigo group-focus-visible:text-brand-indigo">View project →</p>
+      ) : null}
+    </article>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
+}

--- a/portfolio/src/components/Footer.tsx
+++ b/portfolio/src/components/Footer.tsx
@@ -1,11 +1,41 @@
-import React from "react";
+import { FiGithub, FiLinkedin } from "react-icons/fi";
 
-export function Footer() {
-    return (
-        <footer className=" text-xs fixed bottom-0 w-full px-6 py-4 flex items-center justify-between bg-neutral-500-950/40 text-neutral-400 text-sm  border-neutral-800 z-40">
-            <div className="flex-1 ">© {new Date().getFullYear()} Cameron Loveland</div>
-            <div className="flex-1 text-right">
-            </div>
-        </footer >
-    );
+const socials = [
+  {
+    name: "GitHub",
+    href: "https://github.com/cameronloveland",
+    icon: FiGithub,
+  },
+  {
+    name: "LinkedIn",
+    href: "https://www.linkedin.com/in/cameronloveland/",
+    icon: FiLinkedin,
+  },
+];
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-slate-200 bg-white/90">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <p className="font-medium text-slate-600">© {new Date().getFullYear()} Cameron Loveland. All rights reserved.</p>
+        <div className="flex items-center gap-4">
+          {socials.map((social) => {
+            const Icon = social.icon;
+            return (
+              <a
+                key={social.name}
+                href={social.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-2 rounded-full px-3 py-2 font-semibold text-slate-600 transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              >
+                <Icon className="h-4 w-4" aria-hidden />
+                <span>{social.name}</span>
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </footer>
+  );
 }

--- a/portfolio/src/components/Footer.tsx
+++ b/portfolio/src/components/Footer.tsx
@@ -17,7 +17,7 @@ export default function Footer() {
   return (
     <footer className="border-t border-slate-200 bg-white/90">
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-        <p className="font-medium text-slate-600">© {new Date().getFullYear()} Cameron Loveland. All rights reserved.</p>
+        <p className="font-medium text-brand-midnight">© {new Date().getFullYear()} Cameron Loveland. All rights reserved.</p>
         <div className="flex items-center gap-4">
           {socials.map((social) => {
             const Icon = social.icon;
@@ -27,7 +27,7 @@ export default function Footer() {
                 href={social.href}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex items-center gap-2 rounded-full px-3 py-2 font-semibold text-slate-600 transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="inline-flex items-center gap-2 rounded-full px-3 py-2 font-semibold text-brand-midnight transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 <Icon className="h-4 w-4" aria-hidden />
                 <span>{social.name}</span>

--- a/portfolio/src/components/Header.tsx
+++ b/portfolio/src/components/Header.tsx
@@ -1,58 +1,68 @@
-'use client';
+"use client";
 
-import { FaGithub } from 'react-icons/fa6';
-import { AudioToggle } from './audio';
+import Link from "next/link";
+import { useState } from "react";
+import { FiMenu, FiX } from "react-icons/fi";
+
+const navigation = [
+  { name: "Home", href: "#top" },
+  { name: "Projects", href: "#projects" },
+  { name: "Contact", href: "#contact" },
+];
 
 export default function Header() {
-    return (
-        <header className="z-50 fixed top-0 left-0 w-full bg-neutral-950/80 backdrop-blur border-neutral-900 transition-colors duration-300">
+  const [isOpen, setIsOpen] = useState(false);
 
-            <div className="max-w-6xl mx-auto flex items-center justify-between px-6 py-4 relative" >
-                {/* Left: Logo */}
-                <a
-                    href="https://github.com/cameronloveland"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="link-style flex items-center gap-3"
-                    aria-label="GitHub Portfolio"
-                >
-                    <img
-                        src="https://github.com/cameronloveland.png"
-                        alt="Cameron Loveland"
-                        className="w-8 h-8 rounded-full border-2 border-neutral-700 shadow-sm"
-                    />
-                    <span className="font-bold text-lg tracking-tight">
-                        <span className="text-accent">cameron</span>
-                        <span className="text-secondary">.loveland</span>
-                        <span className="text-neutral-400"> / portfolio</span>
-                    </span>
-                </a>
+  const toggleMenu = () => setIsOpen((prev) => !prev);
+  const closeMenu = () => setIsOpen(false);
 
-                {/* Center: Social icons */}
-                <div className="hidden sm:flex items-center gap-3 absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-                    <a
-                        href="https://github.com/cameronloveland"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="button-style"
-                        aria-label="GitHub"
-                    >
-                        <FaGithub className="text-lg" />
-                    </a>
-                    {/* <a
-                      href="https://linkedin.com/in/your-linkedin"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="button-style"
-                      aria-label="LinkedIn"
-                  >
-                      <FaLinkedin className="text-lg" />
-                  </a> */}
-                </div>
-
-                {/* Right: Audio toggle */}
-                <AudioToggle />
-            </div>
-        </header>
-    );
+  return (
+    <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/90 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+        <Link
+          href="/"
+          className="flex items-center gap-2 text-lg font-semibold text-slate-900 transition hover:text-brand-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          onClick={closeMenu}
+        >
+          Cameron Loveland
+        </Link>
+        <nav className="hidden items-center gap-8 text-sm font-medium text-slate-600 sm:flex" aria-label="Primary">
+          {navigation.map((item) => (
+            <a
+              key={item.name}
+              href={item.href}
+              className="rounded-full px-3 py-2 text-sm font-semibold text-slate-600 transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            >
+              {item.name}
+            </a>
+          ))}
+        </nav>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:hidden"
+          aria-label={isOpen ? "Close navigation" : "Open navigation"}
+          aria-expanded={isOpen}
+          onClick={toggleMenu}
+        >
+          {isOpen ? <FiX className="h-5 w-5" /> : <FiMenu className="h-5 w-5" />}
+        </button>
+      </div>
+      {isOpen ? (
+        <div className="border-t border-slate-200 bg-white sm:hidden">
+          <nav className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-4" aria-label="Mobile navigation">
+            {navigation.map((item) => (
+              <a
+                key={item.name}
+                href={item.href}
+                className="rounded-2xl px-4 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                onClick={closeMenu}
+              >
+                {item.name}
+              </a>
+            ))}
+          </nav>
+        </div>
+      ) : null}
+    </header>
+  );
 }

--- a/portfolio/src/components/Header.tsx
+++ b/portfolio/src/components/Header.tsx
@@ -21,17 +21,17 @@ export default function Header() {
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
         <Link
           href="/"
-          className="flex items-center gap-2 text-lg font-semibold text-slate-900 transition hover:text-brand-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          className="flex items-center gap-2 text-lg font-semibold text-brand-midnight transition hover:text-brand-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           onClick={closeMenu}
         >
           Cameron Loveland
         </Link>
-        <nav className="hidden items-center gap-8 text-sm font-medium text-slate-600 sm:flex" aria-label="Primary">
+        <nav className="hidden items-center gap-8 text-sm font-semibold text-brand-midnight sm:flex" aria-label="Primary">
           {navigation.map((item) => (
             <a
               key={item.name}
               href={item.href}
-              className="rounded-full px-3 py-2 text-sm font-semibold text-slate-600 transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              className="rounded-full px-3 py-2 transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
               {item.name}
             </a>
@@ -39,7 +39,7 @@ export default function Header() {
         </nav>
         <button
           type="button"
-          className="inline-flex items-center justify-center rounded-full p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:hidden"
+          className="inline-flex items-center justify-center rounded-full p-2 text-brand-midnight transition hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:hidden"
           aria-label={isOpen ? "Close navigation" : "Open navigation"}
           aria-expanded={isOpen}
           onClick={toggleMenu}
@@ -54,7 +54,7 @@ export default function Header() {
               <a
                 key={item.name}
                 href={item.href}
-                className="rounded-2xl px-4 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="rounded-2xl px-4 py-3 text-sm font-semibold text-brand-midnight transition hover:bg-slate-100 hover:text-brand-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                 onClick={closeMenu}
               >
                 {item.name}

--- a/portfolio/src/styles/fonts.css
+++ b/portfolio/src/styles/fonts.css
@@ -1,10 +1,6 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;600&display=swap');
-/* @import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap'); */
-
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@600;700&display=swap');
 
 :root {
-  --font-heading: 'JetBrains Mono', monospace;
-  --font-body: 'Roboto Mono', monospace;
-  /* --font-digital: 'Share Tech Mono', monospace; */
+  --font-heading: 'Plus Jakarta Sans', 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-body: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }

--- a/portfolio/src/styles/theme.css
+++ b/portfolio/src/styles/theme.css
@@ -1,152 +1,43 @@
 @import "tailwindcss";
 
 :root {
+  color-scheme: light;
   --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-body);
-  --font-mono: var(--font-heading);
+  --foreground: #0f172a;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-
+    color-scheme: dark;
+    --background: #0f172a;
+    --foreground: #f8fafc;
   }
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html:focus-within {
+  scroll-behavior: smooth;
 }
 
 body {
+  margin: 0;
+  min-height: 100%;
   background: var(--background);
   color: var(--foreground);
+  font-family: var(--font-body), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
-
-.hud-aside-container {
-  @apply w-full max-w-2xl overflow-hidden;
-  max-height: 25vh;
+a {
+  color: inherit;
 }
 
-@media (max-width: 768px) {
-  .hud-aside-container {
-    min-height: 33vh;
-  }
+a:hover {
+  color: inherit;
 }
 
-.hud-panel {
-  background-color: rgba(12, 15, 28, 0.6);
-  border: 1px solid rgba(34, 255, 255, 0.2);
-  border-radius: 1rem;
-  box-shadow: 0 0 10px 1px rgba(34, 255, 255, 0.15);
-  backdrop-filter: blur(12px);
-  padding: 1rem;
-}
-
-.hud-panel-clear {
-  background-color: transparent;
-  border: none;
-  border-radius: 1rem;
-  box-shadow: none;
-  backdrop-filter: blur(12px);
-  padding: 1rem;
-}
-
-.digital-glow {
-  text-shadow: 0 0 4px rgba(0, 255, 255, 0.6), 0 0 8px rgba(0, 255, 255, 0.3);
-}
-
-.link-style {
-  @apply hover:animate-pulse hover:text-cyan-300 transition;
-}
-
-.button-style {
-  @apply hover:animate-pulse hover:text-cyan-300 transition;
-}
-
-.hud-scroll::-webkit-scrollbar {
-  width: 14px;
-}
-
-.hud-scroll::-webkit-scrollbar-track {
-  background: rgba(12, 15, 28, 0.3);
-  border-radius: 8px;
-}
-
-.hud-scroll::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(103, 232, 249, 0.4), rgba(0, 188, 212, 0.6));
-  border-radius: 8px;
-  border: 1px solid rgba(0, 255, 255, 0.3);
-  box-shadow:
-    0 0 6px rgba(0, 255, 255, 0.3),
-    0 0 12px rgba(0, 255, 255, 0.2),
-    inset 0 0 4px rgba(0, 255, 255, 0.4);
-  transition: background 0.2s ease, box-shadow 0.2s ease;
-  animation: hudScrollPulse 2.5s ease-in-out infinite;
-}
-
-.hud-scroll::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(180deg, rgba(103, 232, 249, 0.8), rgba(0, 188, 212, 1));
-  box-shadow:
-    0 0 12px rgba(0, 255, 255, 0.8),
-    0 0 24px rgba(0, 255, 255, 0.6),
-    inset 0 0 10px rgba(0, 255, 255, 0.6);
-  animation: hudScrollPulseHover 1.2s ease-in-out infinite;
-}
-
-
-.hud-scroll {
-  scrollbar-width: thin;
-  scrollbar-color: #00ffff20 transparent;
-}
-
-@keyframes hudScrollPulseHover {
-
-  0%,
-  100% {
-    box-shadow:
-      0 0 10px rgba(0, 255, 255, 0.8),
-      0 0 20px rgba(0, 255, 255, 0.5),
-      inset 0 0 8px rgba(0, 255, 255, 0.5);
-  }
-
-  50% {
-    box-shadow:
-      0 0 16px rgba(0, 255, 255, 1),
-      0 0 32px rgba(0, 255, 255, 0.8),
-      inset 0 0 12px rgba(0, 255, 255, 0.8);
-  }
-}
-
-
-/* Outer circuit intensity pulse */
-@keyframes circuitPulse {
-
-  0%,
-  100% {
-    border-color: rgba(0, 255, 255, 0.2);
-    box-shadow:
-      0 0 8px rgba(0, 255, 255, 0.2),
-      inset 0 0 6px rgba(0, 255, 255, 0.1);
-  }
-
-  50% {
-    border-color: rgba(0, 255, 255, 0.4);
-    box-shadow:
-      0 0 12px rgba(0, 255, 255, 0.4),
-      inset 0 0 8px rgba(0, 255, 255, 0.15);
-  }
-}
-
-@keyframes sweep {
-  0% {
-    top: -100%;
-  }
-
-  100% {
-    top: 100%;
-  }
+::selection {
+  background-color: rgba(14, 165, 233, 0.15);
 }

--- a/portfolio/tailwind.config.js
+++ b/portfolio/tailwind.config.js
@@ -7,8 +7,9 @@ module.exports = {
     extend: {
       colors: {
         brand: {
-          cyan: '#0ea5e9',
-          indigo: '#4c1d95',
+          cyan: '#0d9488',
+          indigo: '#3730a3',
+          midnight: '#0f172a',
         },
       },
       fontFamily: {
@@ -16,7 +17,7 @@ module.exports = {
         heading: ['var(--font-heading)', ...defaultTheme.fontFamily.sans],
       },
       boxShadow: {
-        soft: '0 24px 60px -30px rgba(15, 23, 42, 0.3)',
+        soft: '0 30px 80px -40px rgba(15, 23, 42, 0.35)',
       },
     },
   },

--- a/portfolio/tailwind.config.js
+++ b/portfolio/tailwind.config.js
@@ -1,48 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {
-      keyframes: {
-        twinkle: {
-          '0%, 100%': {
-            opacity: '0.5',
-            transform: 'scale(1)',
-          },
-          '50%': {
-            opacity: '0.8',
-            transform: 'scale(1.1)',
-          },
+      colors: {
+        brand: {
+          cyan: '#0ea5e9',
+          indigo: '#4c1d95',
         },
-        nebulaFloat: {
-          '0%': { transform: 'translate(0,0) scale(1)' },
-          '25%': { transform: 'translate(120px,-80px) scale(1.05)' },
-          '50%': { transform: 'translate(-130px,60px) scale(1.1)' },
-          '75%': { transform: 'translate(80px,120px) scale(1.05)' },
-          '100%': { transform: 'translate(0,0) scale(1)' },
-        },
-        nebulaPulse: {
-          '0%, 100%': { opacity: '0.3' },
-          '50%': { opacity: '0.5' },
-        },
-      },
-      animation: {
-        twinkle: 'twinkle 2s ease-in-out infinite',
-        nebulaFloat: 'nebulaFloat 60s ease-in-out infinite',
-        nebulaPulse: 'nebulaPulse 8s ease-in-out infinite',
       },
       fontFamily: {
-        heading: ['var(--font-heading)', 'sans-serif'],
-        body: ['var(--font-body)', 'sans-serif'],
+        sans: ['var(--font-body)', ...defaultTheme.fontFamily.sans],
+        heading: ['var(--font-heading)', ...defaultTheme.fontFamily.sans],
       },
-      colors: {
-        primary: '#38bdf8',
-        accent: '#38bdf8',
-        secondary: '#64748b',
-        background: '#0f172a',
-        primaryText: '#f8fafc',
+      boxShadow: {
+        soft: '0 24px 60px -30px rgba(15, 23, 42, 0.3)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- replace the cockpit HUD homepage with a clean, mobile-first portfolio layout and new project grid
- add a dedicated Space Cockpit project page and reusable card component
- refresh shared header/footer, typography, and Tailwind design tokens for a professional look

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d48ddec5cc832084e2c558183ad9e4